### PR TITLE
Remove use of deprecated Emotion preset runtime option

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,35 +55,45 @@ module.exports = (babel, options) => {
   }
 
   const reactRuntime = emotion?.runtime ?? react?.runtime ?? 'automatic'
-  const isReactPresetEnabled = react && (emotion ? reactRuntime === 'classic' : true)
+  const isEmotionPluginEnabled = emotion && reactRuntime === 'automatic'
+  const isEmotionPresetEnabled = emotion && reactRuntime !== 'automatic'
 
   const nonNodeModules = {
     exclude: NODE_MODULES_REGEX,
     plugins: [
       [require('@babel/plugin-proposal-class-properties').default, {loose}],
       reactRefresh && [require('react-refresh/babel'), {skipEnvCheck: true, ...reactRefresh}],
+      isEmotionPluginEnabled && [
+        require('babel-plugin-emotion').default,
+        {
+          autoLabel: env === 'development',
+          sourceMap: env === 'development',
+          cssPropOptimization: true,
+          ...emotion,
+        },
+      ],
     ].filter(Boolean),
     presets: [
       typescript && [require('@babel/preset-typescript').default, typescript],
-      isReactPresetEnabled && [
+      react && [
         require('@babel/preset-react').default,
         {
           development: env === 'development',
+          importSource: emotion ? '@emotion/core' : undefined,
           useSpread: true,
           ...react,
           runtime: reactRuntime,
         },
       ],
-      emotion && [
+      isEmotionPresetEnabled && [
         require('@emotion/babel-preset-css-prop').default,
         {
-          development: env === 'development' && reactRuntime === 'automatic',
           useSpread: true,
           autoLabel: env === 'development',
           sourceMap: env === 'development',
           ...react,
           ...emotion,
-          runtime: reactRuntime,
+          runtime: undefined,
         },
       ],
     ].filter(Boolean),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@babel/preset-react": "^7.12.5",
         "@babel/preset-typescript": "^7.12.1",
         "@emotion/babel-preset-css-prop": "^10.2.0",
+        "babel-plugin-emotion": "^10.0.33",
         "react-refresh": "^0.9.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.12.1",
     "@emotion/babel-preset-css-prop": "^10.2.0",
+    "babel-plugin-emotion": "^10.0.33",
     "react-refresh": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Emotion has deprecated the `runtime` option in `@emotion/babel-preset-css-prop` in favor of directly combining `@babel/preset-react` with `babel-plugin-emotion` (see https://github.com/emotion-js/emotion/pull/2074). The Emotion preset now prints a warning when that option is set.

Combining the React preset with the Emotion plugin works well but only supports the automatic runtime. This preset aims to support both runtimes, so the logic is a bit more complicated. We want to use the Emotion preset for the classic runtime, and the Emotion plugin for the automatic runtime.

This doesn't change the preset functionality; it just avoids the runtime deprecation warning.

We could potentially remove support for the classic runtime altogether in the next major version. It just seems strange not to support both when the React preset and Emotion both independently support both.