### PR TITLE
Use env preset to transpile class properties and private methods

### DIFF
--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -484,6 +484,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {
@@ -534,6 +537,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -583,13 +591,21 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/new WeakSet();
+
 var Foo = function Foo() {
   _classCallCheck(this, Foo);
+
+  _privateMethod.add(this);
 
   _defineProperty(this, "baz", function (x, y) {
     return x(_objectSpread({}, y));
   });
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 _defineProperty(Foo, "bar", 'abc');
 
@@ -668,12 +684,20 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/new WeakSet();
+
 class Foo {
   constructor() {
+    _privateMethod.add(this);
+
     _defineProperty(this, "baz", (x, y) => x({ ...y
     }));
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 _defineProperty(Foo, "bar", 'abc');
@@ -716,6 +740,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -764,13 +793,21 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/new WeakSet();
+
 var Foo = function Foo() {
   _classCallCheck(this, Foo);
+
+  _privateMethod.add(this);
 
   _defineProperty(this, "baz", function (x, y) {
     return x(_objectSpread({}, y));
   });
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 _defineProperty(Foo, "bar", 'abc');
 
@@ -849,12 +886,20 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/new WeakSet();
+
 class Foo {
   constructor() {
+    _privateMethod.add(this);
+
     _defineProperty(this, "baz", (x, y) => x({ ...y
     }));
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 _defineProperty(Foo, "bar", 'abc');
@@ -897,6 +942,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {
@@ -945,6 +993,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -995,6 +1048,8 @@ var _objectWithoutPropertiesLoose2 = _interopRequireDefault(require("@babel/runt
 
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
 
+var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
+
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
 
 var _foo = _interopRequireWildcard3(require("foo"));
@@ -1009,11 +1064,21 @@ var dynamicImport = Promise.resolve().then(function () {
   return (0, _interopRequireWildcard2["default"])(require('baz'));
 });
 
+var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2["default"])("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -1091,6 +1156,8 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 exports.__esModule = true;
 exports.obj = exports.default = void 0;
 
+var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
+
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
 
 var _foo = _interopRequireWildcard3(require("foo"));
@@ -1101,12 +1168,22 @@ var _nullishAssignment;
 
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
+var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2.default)("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1163,6 +1240,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -1213,6 +1295,8 @@ var _objectWithoutPropertiesLoose2 = _interopRequireDefault(require("@babel/runt
 
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
 
+var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
+
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
 
 var _foo = _interopRequireWildcard3(require("foo"));
@@ -1227,11 +1311,21 @@ var dynamicImport = Promise.resolve().then(function () {
   return (0, _interopRequireWildcard2["default"])(require('baz'));
 });
 
+var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2["default"])("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -1309,6 +1403,8 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 exports.__esModule = true;
 exports.obj = exports.default = void 0;
 
+var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
+
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
 
 var _foo = _interopRequireWildcard3(require("foo"));
@@ -1319,12 +1415,22 @@ var _nullishAssignment;
 
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
+var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2.default)("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1368,6 +1474,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {
@@ -1414,6 +1523,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -1457,15 +1571,29 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 var _marked = /*#__PURE__*/regeneratorRuntime.mark(infiniteGenerator);
 
+var id = 0;
+
+function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
+
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -1537,16 +1665,30 @@ export { obj };
 exports[`transpiles ES2020+ syntax given {"runtime":false}: output (development-modern) 1`] = `
 var _nullishAssignment;
 
+var id = 0;
+
+function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
+
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1589,6 +1731,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -1631,15 +1778,29 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 var _marked = /*#__PURE__*/regeneratorRuntime.mark(infiniteGenerator);
 
+var id = 0;
+
+function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
+
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -1711,16 +1872,30 @@ export { obj };
 exports[`transpiles ES2020+ syntax given {"runtime":false}: output (production-modern) 1`] = `
 var _nullishAssignment;
 
+var id = 0;
+
+function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
+
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1763,6 +1938,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {
@@ -1811,6 +1989,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -1844,18 +2027,30 @@ exports.default = _default;
 `;
 
 exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (development) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1890,18 +2085,30 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (development-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -1944,6 +2151,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -1976,18 +2188,30 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (production) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -2022,18 +2246,30 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (production-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -2076,6 +2312,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {
@@ -2124,6 +2363,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -2159,6 +2403,7 @@ exports.default = _default;
 exports[`transpiles ES2020+ syntax given {}: output (development) 1`] = `
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
 
@@ -2170,11 +2415,21 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -2244,18 +2499,30 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {}: output (development-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';
@@ -2298,6 +2565,11 @@ class Foo {
   static bar = 'abc';
   baz = (x, y) => x({ ...y
   });
+
+  #privateMethod() {
+    return 1;
+  }
+
 }
 
 function* infiniteGenerator() {
@@ -2332,6 +2604,7 @@ export { obj };
 exports[`transpiles ES2020+ syntax given {}: output (production) 1`] = `
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
 
@@ -2343,11 +2616,21 @@ import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 var dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
   this.baz = function (x, y) {
     return x(Object.assign({}, y));
   };
 };
+
+function _privateMethod2() {
+  return 1;
+}
 
 Foo.bar = 'abc';
 
@@ -2417,18 +2700,30 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {}: output (production-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
 var _nullishAssignment;
 
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
 class Foo {
   constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
     this.baz = (x, y) => x({ ...y
     });
   }
 
+}
+
+function _privateMethod2() {
+  return 1;
 }
 
 Foo.bar = 'abc';

--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -522,8 +522,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.obj = exports.default = void 0;
 
-var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
 
 var _foo = _interopRequireWildcard3(require("foo"));
@@ -533,14 +531,10 @@ var namespaceImport = _interopRequireWildcard3(require("bar"));
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
 class Foo {
-  constructor() {
-    (0, _defineProperty2.default)(this, "baz", (x, y) => x({ ...y
-    }));
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-(0, _defineProperty2.default)(Foo, "bar", 'abc');
 
 function* infiniteGenerator() {
   yield 1;
@@ -714,20 +708,15 @@ export { obj };
 `;
 
 exports[`transpiles ES2020+ syntax given {"loose":false}: output (esm) 1`] = `
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
 class Foo {
-  constructor() {
-    _defineProperty(this, "baz", (x, y) => x({ ...y
-    }));
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-_defineProperty(Foo, "bar", 'abc');
 
 function* infiniteGenerator() {
   yield 1;
@@ -953,14 +942,10 @@ var namespaceImport = _interopRequireWildcard3(require("bar"));
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -1175,14 +1160,10 @@ var namespaceImport = _interopRequireWildcard3(require("bar"));
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -1430,14 +1411,10 @@ function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && 
 const dynamicImport = Promise.resolve().then(() => _interopRequireWildcard(require('baz')));
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -1609,14 +1586,10 @@ import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -1835,14 +1808,10 @@ var namespaceImport = _interopRequireWildcard3(require("bar"));
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -1972,14 +1941,10 @@ import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -2156,14 +2121,10 @@ var namespaceImport = _interopRequireWildcard3(require("bar"));
 const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;
@@ -2334,14 +2295,10 @@ import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
 
 class Foo {
-  constructor() {
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
 }
-
-Foo.bar = 'abc';
 
 function* infiniteGenerator() {
   yield 1;

--- a/fixtures/syntax.js
+++ b/fixtures/syntax.js
@@ -6,6 +6,9 @@ const dynamicImport = import('baz')
 class Foo {
   static bar = 'abc'
   baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
 }
 
 function* infiniteGenerator() {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const NODE_MODULES_REGEX = /node_modules/
 // webpack@4 depends on versions of acorn and terser that lack support for certain modern syntax,
 // so, when transpiling an app, these plugins must be included
 const APP_PLUGIN_INCLUDE_LIST = [
+  '@babel/plugin-proposal-class-properties',
+  '@babel/plugin-proposal-private-methods',
   '@babel/plugin-proposal-logical-assignment-operators',
   '@babel/plugin-proposal-nullish-coalescing-operator',
   '@babel/plugin-proposal-optional-chaining',
@@ -98,7 +100,6 @@ module.exports = (babel, options) => {
   const nonNodeModules = {
     exclude: NODE_MODULES_REGEX,
     plugins: [
-      [require('@babel/plugin-proposal-class-properties').default, {loose}],
       reactRefresh && [require('react-refresh/babel'), {skipEnvCheck: true, ...reactRefresh}],
       isEmotionPluginEnabled && [require('@emotion/babel-plugin').default, {...emotion}],
     ].filter(Boolean),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "17.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-transform-runtime": "^7.14.2",
         "@babel/preset-env": "^7.14.2",
         "@babel/preset-react": "^7.13.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-refresh": "^0.9.0 || ^0.10.0"
   },
   "dependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-transform-runtime": "^7.14.2",
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",


### PR DESCRIPTION
These proposals are now stage 4 and are support by the env preset as of [7.14](https://babeljs.io/blog/2021/04/29/7.14.0#new-class-features-enabled-by-default), so they no longer need to be included explicitly and unconditionally.

They aren't supported by the version of acorn used by webpack 4, so they need to be added to the forced inclusion list for apps until we deprecate support for webpack 4 (https://github.com/kensho-technologies/babel-preset/pull/91).