### PR TITLE
Use compiler assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,6 @@ Default: `['@babel/plugin-proposal-optional-chaining', '@babel/plugin-proposal-n
 
 List of plugins to always include. Forwarded to [the corresponding option in `@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#include).
 
-### `loose`
-
-`true` | `false`<br />
-Default: `true`
-
-Whether to enable [loose mode](http://2ality.com/2015/12/babel6-loose-mode.html) in all presets/plugins that support this option.
-
 ### `modules`
 
 `false` | `'commonjs'`<br />

--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`avoids transpiling known precompiled packages given {}: input 1`] = `
+exports[`avoids transpiling known precompiled packages given {}, {}: input 1`] = `
 export default class React {
   method(value) {
     return value ?? 2
@@ -9,26 +9,26 @@ export default class React {
 
 `;
 
-exports[`avoids transpiling known precompiled packages given {}: output (cjs) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (cjs) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}: output (development) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (development) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}: output (development-modern) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (development-modern) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}: output (esm) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (esm) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}: output (production) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (production) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}: output (production-modern) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`avoids transpiling known precompiled packages given {}, {}: output (production-modern) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: input 1`] = `
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: input 1`] = `
 import 'core-js/stable'
 
 `;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (cjs) 1`] = `"use strict";`;
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (cjs) 1`] = `"use strict";`;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (development) 1`] = `
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (development) 1`] = `
 import "core-js/modules/es.symbol.js";
 import "core-js/modules/es.symbol.description.js";
 import "core-js/modules/es.symbol.async-iterator.js";
@@ -239,11 +239,11 @@ import "core-js/modules/web.url.to-json.js";
 import "core-js/modules/web.url-search-params.js";
 `;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (development-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (development-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (esm) 1`] = ``;
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (esm) 1`] = ``;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (production) 1`] = `
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (production) 1`] = `
 import "core-js/modules/es.symbol.js";
 import "core-js/modules/es.symbol.description.js";
 import "core-js/modules/es.symbol.async-iterator.js";
@@ -454,28 +454,28 @@ import "core-js/modules/web.url.to-json.js";
 import "core-js/modules/web.url-search-params.js";
 `;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}: output (production-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (production-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
 
-exports[`transpiles CJS in node_modules given {}: input 1`] = `
+exports[`transpiles CJS in node_modules given {}, {}: input 1`] = `
 module.exports = function forEach(array, sideEffect) {
   for (const value of array) sideEffect(value)
 }
 
 `;
 
-exports[`transpiles CJS in node_modules given {}: output (cjs) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (cjs) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
-exports[`transpiles CJS in node_modules given {}: output (development) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (development) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
 
-exports[`transpiles CJS in node_modules given {}: output (development-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (development-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
-exports[`transpiles CJS in node_modules given {}: output (esm) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (esm) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
-exports[`transpiles CJS in node_modules given {}: output (production) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (production) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
 
-exports[`transpiles CJS in node_modules given {}: output (production-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
+exports[`transpiles CJS in node_modules given {}, {}: output (production-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: input 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
 import * as namespaceImport from 'bar'
 
@@ -513,7 +513,7 @@ export {obj}
 
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (cjs) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (cjs) 1`] = `
 "use strict";
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
@@ -574,7 +574,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (development) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (development) 1`] = `
 "use strict";
 
 var _regeneratorRuntime2 = require("@babel/runtime/regenerator");
@@ -692,7 +692,7 @@ var _default = obj;
 exports["default"] = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (development-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (development-modern) 1`] = `
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
@@ -766,7 +766,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (esm) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (esm) 1`] = `
 "use strict";
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
@@ -827,7 +827,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (production) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (production) 1`] = `
 "use strict";
 
 var _regeneratorRuntime2 = require("@babel/runtime/regenerator");
@@ -945,7 +945,7 @@ var _default = obj;
 exports["default"] = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: output (production-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (production-modern) 1`] = `
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
@@ -1019,7 +1019,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: input 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
 import * as namespaceImport from 'bar'
 
@@ -1057,7 +1057,7 @@ export {obj}
 
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (cjs) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (cjs) 1`] = `
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1116,7 +1116,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (development) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (development) 1`] = `
 var _nullishAssignment;
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
@@ -1218,7 +1218,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (development-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (development-modern) 1`] = `
 var _nullishAssignment;
 
 var id = 0;
@@ -1278,7 +1278,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (esm) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
@@ -1323,7 +1323,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (production) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (production) 1`] = `
 var _nullishAssignment;
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
@@ -1425,7 +1425,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}: output (production-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (production-modern) 1`] = `
 var _nullishAssignment;
 
 var id = 0;
@@ -1485,7 +1485,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: input 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
 import * as namespaceImport from 'bar'
 
@@ -1523,7 +1523,7 @@ export {obj}
 
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (cjs) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (cjs) 1`] = `
 "use strict";
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
@@ -1584,7 +1584,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (development) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (development) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -1642,7 +1642,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (development-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (development-modern) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -1700,7 +1700,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (esm) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
@@ -1745,7 +1745,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (production) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (production) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -1803,7 +1803,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}: output (production-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (production-modern) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -1861,7 +1861,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}: input 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
 import * as namespaceImport from 'bar'
 
@@ -1899,16 +1899,14 @@ export {obj}
 
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (cjs) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (cjs) 1`] = `
 "use strict";
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
+exports.__esModule = true;
 exports.obj = exports.default = void 0;
 
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
@@ -1960,7 +1958,7 @@ var _default = obj;
 exports.default = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (development) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (development) 1`] = `
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
@@ -2058,7 +2056,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (development-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (development-modern) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -2116,7 +2114,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (esm) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
 const dynamicImport = import('baz');
@@ -2161,7 +2159,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (production) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (production) 1`] = `
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
@@ -2259,7 +2257,7 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}: output (production-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (production-modern) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -2317,26 +2315,482 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ESM in node_modules given {}: input 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {}: input 1`] = `
+import defaultImport, {namedImport} from 'foo'
+import * as namespaceImport from 'bar'
+
+const dynamicImport = import('baz')
+
+class Foo {
+  static bar = 'abc'
+  baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
+}
+
+function* infiniteGenerator() {
+  yield 1
+  yield* infiniteGenerator()
+}
+
+async function asyncFunction() {
+  return await null
+}
+
+const obj = {a: 1, b: 2}
+
+const spread = {...obj, b: 2, c: 3}
+const {a, ...rest} = spread
+
+let nullishAssignment
+nullishAssignment ??= 1
+const nullishCoalescing = obj ?? 1
+const optionalChaining = obj?.b
+
+export default obj
+export {obj}
+
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (cjs) 1`] = `
+"use strict";
+
+var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.obj = exports.default = void 0;
+
+var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
+
+var _foo = _interopRequireWildcard3(require("foo"));
+
+var namespaceImport = _interopRequireWildcard3(require("bar"));
+
+const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
+
+class Foo {
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
+
+  #privateMethod() {
+    return 1;
+  }
+
+}
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+exports.obj = obj;
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+nullishAssignment ?? (nullishAssignment = 1);
+const nullishCoalescing = obj ?? 1;
+const optionalChaining = obj?.b;
+var _default = obj;
+exports.default = _default;
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (development) 1`] = `
+import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
+import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
+var _nullishAssignment;
+
+import _regeneratorRuntime from "@babel/runtime/regenerator";
+
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(infiniteGenerator);
+
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+var dynamicImport = import('baz');
+
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
+var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
+  this.baz = function (x, y) {
+    return x(Object.assign({}, y));
+  };
+};
+
+function _privateMethod2() {
+  return 1;
+}
+
+Foo.bar = 'abc';
+
+function infiniteGenerator() {
+  return _regeneratorRuntime.wrap(function infiniteGenerator$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 1;
+
+        case 2:
+          return _context.delegateYield(infiniteGenerator(), "t0", 3);
+
+        case 3:
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked);
+}
+
+function asyncFunction() {
+  return _asyncFunction.apply(this, arguments);
+}
+
+function _asyncFunction() {
+  _asyncFunction = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
+    return _regeneratorRuntime.wrap(function _callee$(_context2) {
+      while (1) {
+        switch (_context2.prev = _context2.next) {
+          case 0:
+            _context2.next = 2;
+            return null;
+
+          case 2:
+            return _context2.abrupt("return", _context2.sent);
+
+          case 3:
+          case "end":
+            return _context2.stop();
+        }
+      }
+    }, _callee);
+  }));
+  return _asyncFunction.apply(this, arguments);
+}
+
+var obj = {
+  a: 1,
+  b: 2
+};
+var spread = Object.assign({}, obj, {
+  b: 2,
+  c: 3
+});
+
+var a = spread.a,
+    rest = _objectWithoutPropertiesLoose(spread, ["a"]);
+
+var nullishAssignment;
+(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
+var nullishCoalescing = obj != null ? obj : 1;
+var optionalChaining = obj == null ? void 0 : obj.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (development-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
+var _nullishAssignment;
+
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+const dynamicImport = import('baz');
+
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
+    this.baz = (x, y) => x({ ...y
+    });
+  }
+
+}
+
+function _privateMethod2() {
+  return 1;
+}
+
+Foo.bar = 'abc';
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
+const nullishCoalescing = obj != null ? obj : 1;
+const optionalChaining = obj == null ? void 0 : obj.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (esm) 1`] = `
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+const dynamicImport = import('baz');
+
+class Foo {
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
+
+  #privateMethod() {
+    return 1;
+  }
+
+}
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+nullishAssignment ?? (nullishAssignment = 1);
+const nullishCoalescing = obj ?? 1;
+const optionalChaining = obj?.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (production) 1`] = `
+import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
+import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
+var _nullishAssignment;
+
+import _regeneratorRuntime from "@babel/runtime/regenerator";
+
+var _marked = /*#__PURE__*/_regeneratorRuntime.mark(infiniteGenerator);
+
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+var dynamicImport = import('baz');
+
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
+var Foo = function Foo() {
+  Object.defineProperty(this, _privateMethod, {
+    value: _privateMethod2
+  });
+
+  this.baz = function (x, y) {
+    return x(Object.assign({}, y));
+  };
+};
+
+function _privateMethod2() {
+  return 1;
+}
+
+Foo.bar = 'abc';
+
+function infiniteGenerator() {
+  return _regeneratorRuntime.wrap(function infiniteGenerator$(_context) {
+    while (1) {
+      switch (_context.prev = _context.next) {
+        case 0:
+          _context.next = 2;
+          return 1;
+
+        case 2:
+          return _context.delegateYield(infiniteGenerator(), "t0", 3);
+
+        case 3:
+        case "end":
+          return _context.stop();
+      }
+    }
+  }, _marked);
+}
+
+function asyncFunction() {
+  return _asyncFunction.apply(this, arguments);
+}
+
+function _asyncFunction() {
+  _asyncFunction = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
+    return _regeneratorRuntime.wrap(function _callee$(_context2) {
+      while (1) {
+        switch (_context2.prev = _context2.next) {
+          case 0:
+            _context2.next = 2;
+            return null;
+
+          case 2:
+            return _context2.abrupt("return", _context2.sent);
+
+          case 3:
+          case "end":
+            return _context2.stop();
+        }
+      }
+    }, _callee);
+  }));
+  return _asyncFunction.apply(this, arguments);
+}
+
+var obj = {
+  a: 1,
+  b: 2
+};
+var spread = Object.assign({}, obj, {
+  b: 2,
+  c: 3
+});
+
+var a = spread.a,
+    rest = _objectWithoutPropertiesLoose(spread, ["a"]);
+
+var nullishAssignment;
+(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
+var nullishCoalescing = obj != null ? obj : 1;
+var optionalChaining = obj == null ? void 0 : obj.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {}: output (production-modern) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
+var _nullishAssignment;
+
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+const dynamicImport = import('baz');
+
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
+    this.baz = (x, y) => x({ ...y
+    });
+  }
+
+}
+
+function _privateMethod2() {
+  return 1;
+}
+
+Foo.bar = 'abc';
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
+const nullishCoalescing = obj != null ? obj : 1;
+const optionalChaining = obj == null ? void 0 : obj.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ESM in node_modules given {}, {}: input 1`] = `
 export function map(value) {
   return value ?? 2
 }
 
 `;
 
-exports[`transpiles ESM in node_modules given {}: output (cjs) 1`] = `"use strict";Object.defineProperty(exports,"__esModule",{value:true});exports.map=map;function map(value){return value??2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (cjs) 1`] = `"use strict";Object.defineProperty(exports,"__esModule",{value:true});exports.map=map;function map(value){return value??2;}`;
 
-exports[`transpiles ESM in node_modules given {}: output (development) 1`] = `export function map(value){return value!=null?value:2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (development) 1`] = `export function map(value){return value!=null?value:2;}`;
 
-exports[`transpiles ESM in node_modules given {}: output (development-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (development-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
 
-exports[`transpiles ESM in node_modules given {}: output (esm) 1`] = `export function map(value){return value??2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (esm) 1`] = `export function map(value){return value??2;}`;
 
-exports[`transpiles ESM in node_modules given {}: output (production) 1`] = `export function map(value){return value!=null?value:2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (production) 1`] = `export function map(value){return value!=null?value:2;}`;
 
-exports[`transpiles ESM in node_modules given {}: output (production-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
+exports[`transpiles ESM in node_modules given {}, {}: output (production-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
 
-exports[`transpiles Emotion given {"emotion":true}: input 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: input 1`] = `
 import {useState} from 'react'
 import {css} from '@emotion/react'
 
@@ -2357,7 +2811,7 @@ export default function MyComponent(props) {
 
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (cjs) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (cjs) 1`] = `
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -2414,7 +2868,7 @@ function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (development) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (development) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -2493,7 +2947,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (development-modern) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (development-modern) 1`] = `
 var _jsxFileName = "/emotion.js",
     _s = $RefreshSig$();
 
@@ -2562,7 +3016,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (esm) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (esm) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
 import { useState } from 'react';
@@ -2611,7 +3065,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (production) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (production) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -2670,7 +3124,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion given {"emotion":true}: output (production-modern) 1`] = `
+exports[`transpiles Emotion given {"emotion":true}, {}: output (production-modern) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
 import { useState } from 'react';
@@ -2719,7 +3173,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: input 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: input 1`] = `
 import * as React from 'react'
 import {css} from '@emotion/react'
 
@@ -2740,7 +3194,7 @@ export default function MyComponent(props) {
 
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (cjs) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (cjs) 1`] = `
 "use strict";
 
 var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard").default;
@@ -2794,7 +3248,7 @@ function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (development) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (development) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -2873,7 +3327,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (development-modern) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (development-modern) 1`] = `
 var _jsxFileName = "/emotion-classic.js",
     _s = $RefreshSig$();
 
@@ -2942,7 +3396,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (esm) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (esm) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
 import * as React from 'react';
@@ -2986,7 +3440,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (production) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (production) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -3040,7 +3494,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (production-modern) 1`] = `
+exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (production-modern) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
 import * as React from 'react';
@@ -3084,7 +3538,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React given {}: input 1`] = `
+exports[`transpiles React given {}, {}: input 1`] = `
 import {useState} from 'react'
 
 export default function MyComponent(props) {
@@ -3099,7 +3553,7 @@ export default function MyComponent(props) {
 
 `;
 
-exports[`transpiles React given {}: output (cjs) 1`] = `
+exports[`transpiles React given {}, {}: output (cjs) 1`] = `
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3125,7 +3579,7 @@ function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React given {}: output (development) 1`] = `
+exports[`transpiles React given {}, {}: output (development) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -3167,7 +3621,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React given {}: output (development-modern) 1`] = `
+exports[`transpiles React given {}, {}: output (development-modern) 1`] = `
 var _jsxFileName = "/react.js",
     _s = $RefreshSig$();
 
@@ -3201,7 +3655,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React given {}: output (esm) 1`] = `
+exports[`transpiles React given {}, {}: output (esm) 1`] = `
 import { useState } from 'react';
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export default function MyComponent(props) {
@@ -3218,7 +3672,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React given {}: output (production) 1`] = `
+exports[`transpiles React given {}, {}: output (production) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import { useState } from 'react';
@@ -3242,7 +3696,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React given {}: output (production-modern) 1`] = `
+exports[`transpiles React given {}, {}: output (production-modern) 1`] = `
 import { useState } from 'react';
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export default function MyComponent(props) {
@@ -3259,7 +3713,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: input 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: input 1`] = `
 import * as React from 'react'
 
 export default function MyComponent(props) {
@@ -3274,7 +3728,7 @@ export default function MyComponent(props) {
 
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (cjs) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (cjs) 1`] = `
 "use strict";
 
 var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard").default;
@@ -3299,7 +3753,7 @@ function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (development) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (development) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
@@ -3341,7 +3795,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (development-modern) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (development-modern) 1`] = `
 var _jsxFileName = "/react-classic.js",
     _s = $RefreshSig$();
 
@@ -3375,7 +3829,7 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (esm) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (esm) 1`] = `
 import * as React from 'react';
 export default function MyComponent(props) {
   const {
@@ -3390,7 +3844,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (production) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (production) 1`] = `
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import * as React from 'react';
@@ -3411,7 +3865,7 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (production-modern) 1`] = `
+exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (production-modern) 1`] = `
 import * as React from 'react';
 export default function MyComponent(props) {
   const {
@@ -3426,14 +3880,14 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles TSX given {}: input 1`] = `
+exports[`transpiles TSX given {}, {}: input 1`] = `
 export default function add(a: number, b: number): number {
   return a + b
 }
 
 `;
 
-exports[`transpiles TSX given {}: output (cjs) 1`] = `
+exports[`transpiles TSX given {}, {}: output (cjs) 1`] = `
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -3446,31 +3900,31 @@ function add(a, b) {
 }
 `;
 
-exports[`transpiles TSX given {}: output (development) 1`] = `
+exports[`transpiles TSX given {}, {}: output (development) 1`] = `
 export default function add(a, b) {
   return a + b;
 }
 `;
 
-exports[`transpiles TSX given {}: output (development-modern) 1`] = `
+exports[`transpiles TSX given {}, {}: output (development-modern) 1`] = `
 export default function add(a, b) {
   return a + b;
 }
 `;
 
-exports[`transpiles TSX given {}: output (esm) 1`] = `
+exports[`transpiles TSX given {}, {}: output (esm) 1`] = `
 export default function add(a, b) {
   return a + b;
 }
 `;
 
-exports[`transpiles TSX given {}: output (production) 1`] = `
+exports[`transpiles TSX given {}, {}: output (production) 1`] = `
 export default function add(a, b) {
   return a + b;
 }
 `;
 
-exports[`transpiles TSX given {}: output (production-modern) 1`] = `
+exports[`transpiles TSX given {}, {}: output (production-modern) 1`] = `
 export default function add(a, b) {
   return a + b;
 }

--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -520,7 +520,9 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
@@ -581,7 +583,9 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard")["default"];
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports["default"] = void 0;
 
 var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
@@ -695,7 +699,9 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
@@ -767,7 +773,9 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
@@ -828,7 +836,9 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard")["default"];
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports["default"] = void 0;
 
 var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
@@ -942,7 +952,9 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
@@ -1048,7 +1060,9 @@ export {obj}
 exports[`transpiles ES2020+ syntax given {"runtime":false}: output (cjs) 1`] = `
 "use strict";
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _foo = _interopRequireWildcard(require("foo"));
@@ -1516,7 +1530,9 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
@@ -1890,7 +1906,9 @@ var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWil
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.obj = exports.default = void 0;
 
 var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
@@ -2306,7 +2324,7 @@ export function map(value) {
 
 `;
 
-exports[`transpiles ESM in node_modules given {}: output (cjs) 1`] = `"use strict";exports.__esModule=true;exports.map=map;function map(value){return value??2;}`;
+exports[`transpiles ESM in node_modules given {}: output (cjs) 1`] = `"use strict";Object.defineProperty(exports,"__esModule",{value:true});exports.map=map;function map(value){return value??2;}`;
 
 exports[`transpiles ESM in node_modules given {}: output (development) 1`] = `export function map(value){return value!=null?value:2;}`;
 
@@ -2342,7 +2360,9 @@ export default function MyComponent(props) {
 exports[`transpiles Emotion given {"emotion":true}: output (cjs) 1`] = `
 "use strict";
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.default = MyComponent;
 
 var _react = require("react");
@@ -2725,7 +2745,9 @@ exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{
 
 var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.default = MyComponent;
 
 var React = _interopRequireWildcard(require("react"));
@@ -3080,7 +3102,9 @@ export default function MyComponent(props) {
 exports[`transpiles React given {}: output (cjs) 1`] = `
 "use strict";
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.default = MyComponent;
 
 var _react = require("react");
@@ -3255,7 +3279,9 @@ exports[`transpiles React with classic runtime given {"react":{"runtime":"classi
 
 var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard").default;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.default = MyComponent;
 
 var React = _interopRequireWildcard(require("react"));
@@ -3410,7 +3436,9 @@ export default function add(a: number, b: number): number {
 exports[`transpiles TSX given {}: output (cjs) 1`] = `
 "use strict";
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
 exports.default = add;
 
 function add(a, b) {

--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -475,464 +475,6 @@ exports[`transpiles CJS in node_modules given {}: output (production) 1`] = `var
 
 exports[`transpiles CJS in node_modules given {}: output (production-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
-exports[`transpiles ES2020+ syntax given {"loose":false}: input 1`] = `
-import defaultImport, {namedImport} from 'foo'
-import * as namespaceImport from 'bar'
-
-const dynamicImport = import('baz')
-
-class Foo {
-  static bar = 'abc'
-  baz = (x, y) => x({...y})
-  #privateMethod() {
-    return 1
-  }
-}
-
-function* infiniteGenerator() {
-  yield 1
-  yield* infiniteGenerator()
-}
-
-async function asyncFunction() {
-  return await null
-}
-
-const obj = {a: 1, b: 2}
-
-const spread = {...obj, b: 2, c: 3}
-const {a, ...rest} = spread
-
-let nullishAssignment
-nullishAssignment ??= 1
-const nullishCoalescing = obj ?? 1
-const optionalChaining = obj?.b
-
-export default obj
-export {obj}
-
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (cjs) 1`] = `
-"use strict";
-
-var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
-
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.obj = exports.default = void 0;
-
-var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
-
-var _foo = _interopRequireWildcard3(require("foo"));
-
-var namespaceImport = _interopRequireWildcard3(require("bar"));
-
-const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
-
-class Foo {
-  static bar = 'abc';
-  baz = (x, y) => x({ ...y
-  });
-
-  #privateMethod() {
-    return 1;
-  }
-
-}
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-exports.obj = obj;
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-nullishAssignment ?? (nullishAssignment = 1);
-const nullishCoalescing = obj ?? 1;
-const optionalChaining = obj?.b;
-var _default = obj;
-exports.default = _default;
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (development) 1`] = `
-import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
-import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
-import _objectSpread from "@babel/runtime/helpers/objectSpread2";
-import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
-
-var _nullishAssignment;
-
-import _regeneratorRuntime from "@babel/runtime/regenerator";
-
-var _marked = /*#__PURE__*/_regeneratorRuntime.mark(infiniteGenerator);
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-var dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/new WeakSet();
-
-var Foo = function Foo() {
-  _classCallCheck(this, Foo);
-
-  _privateMethod.add(this);
-
-  _defineProperty(this, "baz", function (x, y) {
-    return x(_objectSpread({}, y));
-  });
-};
-
-function _privateMethod2() {
-  return 1;
-}
-
-_defineProperty(Foo, "bar", 'abc');
-
-function infiniteGenerator() {
-  return _regeneratorRuntime.wrap(function infiniteGenerator$(_context) {
-    while (1) {
-      switch (_context.prev = _context.next) {
-        case 0:
-          _context.next = 2;
-          return 1;
-
-        case 2:
-          return _context.delegateYield(infiniteGenerator(), "t0", 3);
-
-        case 3:
-        case "end":
-          return _context.stop();
-      }
-    }
-  }, _marked);
-}
-
-function asyncFunction() {
-  return _asyncFunction.apply(this, arguments);
-}
-
-function _asyncFunction() {
-  _asyncFunction = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
-    return _regeneratorRuntime.wrap(function _callee$(_context2) {
-      while (1) {
-        switch (_context2.prev = _context2.next) {
-          case 0:
-            _context2.next = 2;
-            return null;
-
-          case 2:
-            return _context2.abrupt("return", _context2.sent);
-
-          case 3:
-          case "end":
-            return _context2.stop();
-        }
-      }
-    }, _callee);
-  }));
-  return _asyncFunction.apply(this, arguments);
-}
-
-var obj = {
-  a: 1,
-  b: 2
-};
-
-var spread = _objectSpread(_objectSpread({}, obj), {}, {
-  b: 2,
-  c: 3
-});
-
-var a = spread.a,
-    rest = _objectWithoutProperties(spread, ["a"]);
-
-var nullishAssignment;
-(_nullishAssignment = nullishAssignment) !== null && _nullishAssignment !== void 0 ? _nullishAssignment : nullishAssignment = 1;
-var nullishCoalescing = obj !== null && obj !== void 0 ? obj : 1;
-var optionalChaining = obj === null || obj === void 0 ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (development-modern) 1`] = `
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/new WeakSet();
-
-class Foo {
-  constructor() {
-    _privateMethod.add(this);
-
-    _defineProperty(this, "baz", (x, y) => x({ ...y
-    }));
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-_defineProperty(Foo, "bar", 'abc');
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) !== null && _nullishAssignment !== void 0 ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj !== null && obj !== void 0 ? obj : 1;
-const optionalChaining = obj === null || obj === void 0 ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (esm) 1`] = `
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-class Foo {
-  static bar = 'abc';
-  baz = (x, y) => x({ ...y
-  });
-
-  #privateMethod() {
-    return 1;
-  }
-
-}
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-nullishAssignment ?? (nullishAssignment = 1);
-const nullishCoalescing = obj ?? 1;
-const optionalChaining = obj?.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (production) 1`] = `
-import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
-import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
-import _objectSpread from "@babel/runtime/helpers/objectSpread2";
-import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
-
-var _nullishAssignment;
-
-import _regeneratorRuntime from "@babel/runtime/regenerator";
-
-var _marked = /*#__PURE__*/_regeneratorRuntime.mark(infiniteGenerator);
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-var dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/new WeakSet();
-
-var Foo = function Foo() {
-  _classCallCheck(this, Foo);
-
-  _privateMethod.add(this);
-
-  _defineProperty(this, "baz", function (x, y) {
-    return x(_objectSpread({}, y));
-  });
-};
-
-function _privateMethod2() {
-  return 1;
-}
-
-_defineProperty(Foo, "bar", 'abc');
-
-function infiniteGenerator() {
-  return _regeneratorRuntime.wrap(function infiniteGenerator$(_context) {
-    while (1) {
-      switch (_context.prev = _context.next) {
-        case 0:
-          _context.next = 2;
-          return 1;
-
-        case 2:
-          return _context.delegateYield(infiniteGenerator(), "t0", 3);
-
-        case 3:
-        case "end":
-          return _context.stop();
-      }
-    }
-  }, _marked);
-}
-
-function asyncFunction() {
-  return _asyncFunction.apply(this, arguments);
-}
-
-function _asyncFunction() {
-  _asyncFunction = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee() {
-    return _regeneratorRuntime.wrap(function _callee$(_context2) {
-      while (1) {
-        switch (_context2.prev = _context2.next) {
-          case 0:
-            _context2.next = 2;
-            return null;
-
-          case 2:
-            return _context2.abrupt("return", _context2.sent);
-
-          case 3:
-          case "end":
-            return _context2.stop();
-        }
-      }
-    }, _callee);
-  }));
-  return _asyncFunction.apply(this, arguments);
-}
-
-var obj = {
-  a: 1,
-  b: 2
-};
-
-var spread = _objectSpread(_objectSpread({}, obj), {}, {
-  b: 2,
-  c: 3
-});
-
-var a = spread.a,
-    rest = _objectWithoutProperties(spread, ["a"]);
-
-var nullishAssignment;
-(_nullishAssignment = nullishAssignment) !== null && _nullishAssignment !== void 0 ? _nullishAssignment : nullishAssignment = 1;
-var nullishCoalescing = obj !== null && obj !== void 0 ? obj : 1;
-var optionalChaining = obj === null || obj === void 0 ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"loose":false}: output (production-modern) 1`] = `
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/new WeakSet();
-
-class Foo {
-  constructor() {
-    _privateMethod.add(this);
-
-    _defineProperty(this, "baz", (x, y) => x({ ...y
-    }));
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-_defineProperty(Foo, "bar", 'abc');
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) !== null && _nullishAssignment !== void 0 ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj !== null && obj !== void 0 ? obj : 1;
-const optionalChaining = obj === null || obj === void 0 ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
 exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
 import * as namespaceImport from 'bar'
@@ -2853,6 +2395,7 @@ function MyComponent(props) {
 `;
 
 exports[`transpiles Emotion given {"emotion":true}: output (development) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 var _jsxFileName = "/emotion.js",
@@ -2892,8 +2435,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["a", "b"]);
 
   var _useState = useState(0),
-      count = _useState[0],
-      setCount = _useState[1];
+      _useState2 = _slicedToArray(_useState, 2),
+      count = _useState2[0],
+      setCount = _useState2[1];
 
   return _jsxDEV(_Fragment, {
     children: [_jsxDEV("button", {
@@ -3048,6 +2592,7 @@ export default function MyComponent(props) {
 `;
 
 exports[`transpiles Emotion given {"emotion":true}: output (production) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
@@ -3083,8 +2628,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["a", "b"]);
 
   var _useState = useState(0),
-      count = _useState[0],
-      setCount = _useState[1];
+      _useState2 = _slicedToArray(_useState, 2),
+      count = _useState2[0],
+      setCount = _useState2[1];
 
   return _jsxs(_Fragment, {
     children: [_jsx("button", {
@@ -3227,6 +2773,7 @@ function MyComponent(props) {
 `;
 
 exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (development) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 var _jsxFileName = "/emotion-classic.js",
@@ -3265,8 +2812,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["a", "b"]);
 
   var _React$useState = React.useState(0),
-      count = _React$useState[0],
-      setCount = _React$useState[1];
+      _React$useState2 = _slicedToArray(_React$useState, 2),
+      count = _React$useState2[0],
+      setCount = _React$useState2[1];
 
   return ___EmotionJSX(React.Fragment, null, ___EmotionJSX("button", {
     css: _ref,
@@ -3417,6 +2965,7 @@ export default function MyComponent(props) {
 `;
 
 exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}: output (production) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
@@ -3450,8 +2999,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["a", "b"]);
 
   var _React$useState = React.useState(0),
-      count = _React$useState[0],
-      setCount = _React$useState[1];
+      _React$useState2 = _slicedToArray(_React$useState, 2),
+      count = _React$useState2[0],
+      setCount = _React$useState2[1];
 
   return ___EmotionJSX(React.Fragment, null, ___EmotionJSX("button", {
     css: _ref,
@@ -3552,6 +3102,7 @@ function MyComponent(props) {
 `;
 
 exports[`transpiles React given {}: output (development) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 var _jsxFileName = "/react.js",
@@ -3566,8 +3117,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["label"]);
 
   var _useState = useState(0),
-      count = _useState[0],
-      setCount = _useState[1];
+      _useState2 = _slicedToArray(_useState, 2),
+      count = _useState2[0],
+      setCount = _useState2[1];
 
   return /*#__PURE__*/_jsxDEV("button", Object.assign({
     onClick: function onClick() {
@@ -3643,6 +3195,7 @@ export default function MyComponent(props) {
 `;
 
 exports[`transpiles React given {}: output (production) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import { useState } from 'react';
 import { jsxs as _jsxs } from "react/jsx-runtime";
@@ -3651,8 +3204,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["label"]);
 
   var _useState = useState(0),
-      count = _useState[0],
-      setCount = _useState[1];
+      _useState2 = _slicedToArray(_useState, 2),
+      count = _useState2[0],
+      setCount = _useState2[1];
 
   return /*#__PURE__*/_jsxs("button", Object.assign({
     onClick: function onClick() {
@@ -3720,6 +3274,7 @@ function MyComponent(props) {
 `;
 
 exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (development) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 
 var _jsxFileName = "/react-classic.js",
@@ -3733,8 +3288,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["label"]);
 
   var _React$useState = React.useState(0),
-      count = _React$useState[0],
-      setCount = _React$useState[1];
+      _React$useState2 = _slicedToArray(_React$useState, 2),
+      count = _React$useState2[0],
+      setCount = _React$useState2[1];
 
   return /*#__PURE__*/React.createElement("button", Object.assign({
     onClick: function onClick() {
@@ -3809,6 +3365,7 @@ export default function MyComponent(props) {
 `;
 
 exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}: output (production) 1`] = `
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _objectWithoutPropertiesLoose from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
 import * as React from 'react';
 export default function MyComponent(props) {
@@ -3816,8 +3373,9 @@ export default function MyComponent(props) {
       rest = _objectWithoutPropertiesLoose(props, ["label"]);
 
   var _React$useState = React.useState(0),
-      count = _React$useState[0],
-      setCount = _React$useState[1];
+      _React$useState2 = _slicedToArray(_React$useState, 2),
+      count = _React$useState2[0],
+      setCount = _React$useState2[1];
 
   return /*#__PURE__*/React.createElement("button", Object.assign({
     onClick: function onClick() {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const APP_PLUGIN_INCLUDE_LIST = [
 const PRECOMPILED_PACKAGES = ['core-js', 'lodash', 'react', 'react-dom', 'whatwg-fetch']
 const PRECOMPILED_PACKAGES_REGEX = new RegExp(`node_modules/(${PRECOMPILED_PACKAGES.join('|')})/`)
 
-const ASSUMPTIONS = {
+const assumptions = {
   constantSuper: true,
   ignoreFunctionLength: true,
   ignoreToPrimitiveHint: true,
@@ -67,7 +67,6 @@ module.exports = (babel, options) => {
   const isProduction = env === 'production' || env === 'production-modern'
 
   const {
-    assumptions = {},
     browserslistEnv = isModern ? 'modern' : undefined,
     emotion = false,
     include = isDevelopment || isProduction ? APP_PLUGIN_INCLUDE_LIST : [],
@@ -88,7 +87,7 @@ module.exports = (babel, options) => {
 
   const nonPrecompiledPackages = {
     exclude: PRECOMPILED_PACKAGES_REGEX,
-    assumptions: {...ASSUMPTIONS, ...assumptions},
+    assumptions,
     plugins: [
       runtime && [
         require('@babel/plugin-transform-runtime').default,

--- a/index.js
+++ b/index.js
@@ -16,13 +16,9 @@ const PRECOMPILED_PACKAGES = ['core-js', 'lodash', 'react', 'react-dom', 'whatwg
 const PRECOMPILED_PACKAGES_REGEX = new RegExp(`node_modules/(${PRECOMPILED_PACKAGES.join('|')})/`)
 
 const ASSUMPTIONS = {
-  // arrayLikeIsIterable: true,
-  constantReexports: true,
   constantSuper: true,
-  enumerableModuleMeta: true,
   ignoreFunctionLength: true,
   ignoreToPrimitiveHint: true,
-  // iterableIsArray: true,
   mutableTemplateObject: true,
   noClassCalls: true,
   noDocumentAll: true,

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const ASSUMPTIONS = {
   enumerableModuleMeta: true,
   ignoreFunctionLength: true,
   ignoreToPrimitiveHint: true,
-  iterableIsArray: true,
+  // iterableIsArray: true,
   mutableTemplateObject: true,
   noClassCalls: true,
   noDocumentAll: true,

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ const APP_PLUGIN_INCLUDE_LIST = [
 const PRECOMPILED_PACKAGES = ['core-js', 'lodash', 'react', 'react-dom', 'whatwg-fetch']
 const PRECOMPILED_PACKAGES_REGEX = new RegExp(`node_modules/(${PRECOMPILED_PACKAGES.join('|')})/`)
 
+// by default, enable most advanced optimizations to roughly match the behavior of `loose` mode,
+// trading off on absolute spec compliance for output size and efficiency
 const assumptions = {
   constantSuper: true,
   ignoreFunctionLength: true,

--- a/index.js
+++ b/index.js
@@ -15,6 +15,29 @@ const APP_PLUGIN_INCLUDE_LIST = [
 const PRECOMPILED_PACKAGES = ['core-js', 'lodash', 'react', 'react-dom', 'whatwg-fetch']
 const PRECOMPILED_PACKAGES_REGEX = new RegExp(`node_modules/(${PRECOMPILED_PACKAGES.join('|')})/`)
 
+const ASSUMPTIONS = {
+  // arrayLikeIsIterable: true,
+  constantReexports: true,
+  constantSuper: true,
+  enumerableModuleMeta: true,
+  ignoreFunctionLength: true,
+  ignoreToPrimitiveHint: true,
+  iterableIsArray: true,
+  mutableTemplateObject: true,
+  noClassCalls: true,
+  noDocumentAll: true,
+  noNewArrows: true,
+  objectRestNoSymbols: true,
+  privateFieldsAsProperties: true,
+  pureGetters: true,
+  setClassMethods: true,
+  setComputedProperties: true,
+  setPublicClassFields: true,
+  setSpreadProperties: true,
+  skipForOfIteratorClosing: true,
+  superIsCallableConstructor: true,
+}
+
 const SUPPORTED_ENVIRONMENTS = [
   'development',
   'production',
@@ -48,10 +71,10 @@ module.exports = (babel, options) => {
   const isProduction = env === 'production' || env === 'production-modern'
 
   const {
+    assumptions = {},
     browserslistEnv = isModern ? 'modern' : undefined,
     emotion = false,
     include = isDevelopment || isProduction ? APP_PLUGIN_INCLUDE_LIST : [],
-    loose = true,
     modules = env === 'test' || env === 'cjs' ? 'commonjs' : false,
     react = {},
     runtime = true,
@@ -69,6 +92,7 @@ module.exports = (babel, options) => {
 
   const nonPrecompiledPackages = {
     exclude: PRECOMPILED_PACKAGES_REGEX,
+    assumptions: {...ASSUMPTIONS, ...assumptions},
     plugins: [
       runtime && [
         require('@babel/plugin-transform-runtime').default,
@@ -82,7 +106,6 @@ module.exports = (babel, options) => {
           ...rest,
           browserslistEnv,
           include,
-          loose,
           modules,
           targets,
           bugfixes: true,

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 
 import {test, expect} from '@jest/globals'
-import {PluginItem, transform, TransformOptions} from '@babel/core'
+import {transform} from '@babel/core'
 
 import preset from '.'
 
@@ -35,15 +35,13 @@ function macro(title: string, fixture: string, presetOptions = {}, topLevelOptio
     }
 
     NON_TEST_ENVIRONMENTS.forEach((envName) => {
-      const presets: PluginItem[] = [[preset, resolvedPresetOptions]]
-      const options: TransformOptions = {
+      const result = transform(input, {
         envName,
-        presets,
+        presets: [[preset, resolvedPresetOptions]],
         filename: `/${fixture}`,
         babelrc: false,
         ...topLevelOptions,
-      }
-      const result = transform(input, options)
+      })
       expect(result?.code).toMatchSnapshot(`output (${envName})`)
     })
   })

--- a/test.ts
+++ b/test.ts
@@ -48,7 +48,6 @@ function macro(title: string, fixture: string, presetOptions = {}): void {
 
 macro('transpiles ES2020+ syntax', 'syntax.js')
 macro('transpiles ES2020+ syntax', 'syntax.js', {targets: 'Chrome 88'})
-macro('transpiles ES2020+ syntax', 'syntax.js', {loose: false})
 macro('transpiles ES2020+ syntax', 'syntax.js', {runtime: false})
 macro('transpiles ES2020+ syntax', 'syntax.js', {modules: 'commonjs'})
 

--- a/test.ts
+++ b/test.ts
@@ -21,8 +21,10 @@ expect.addSnapshotSerializer({
   print: (val: string) => val,
 })
 
-function macro(title: string, fixture: string, presetOptions = {}): void {
-  test(`${title} given ${JSON.stringify(presetOptions)}`, () => {
+function macro(title: string, fixture: string, presetOptions = {}, topLevelOptions = {}): void {
+  const presetOptionsString = JSON.stringify(presetOptions)
+  const topLevelOptionsString = JSON.stringify(topLevelOptions)
+  test(`${title} given ${presetOptionsString}, ${topLevelOptionsString}`, () => {
     const file = `${__dirname}/fixtures/${fixture}`
     const input = fs.readFileSync(file, 'utf8')
     expect(input).toMatchSnapshot('input')
@@ -39,6 +41,7 @@ function macro(title: string, fixture: string, presetOptions = {}): void {
         presets,
         filename: `/${fixture}`,
         babelrc: false,
+        ...topLevelOptions,
       }
       const result = transform(input, options)
       expect(result?.code).toMatchSnapshot(`output (${envName})`)
@@ -50,6 +53,9 @@ macro('transpiles ES2020+ syntax', 'syntax.js')
 macro('transpiles ES2020+ syntax', 'syntax.js', {targets: 'Chrome 88'})
 macro('transpiles ES2020+ syntax', 'syntax.js', {runtime: false})
 macro('transpiles ES2020+ syntax', 'syntax.js', {modules: 'commonjs'})
+macro('transpiles ES2020+ syntax', 'syntax.js', undefined, {
+  assumptions: {enumerableModuleMeta: true},
+})
 
 macro('transpiles React', 'react.js')
 macro('transpiles React with classic runtime', 'react-classic.js', {react: {runtime: 'classic'}})


### PR DESCRIPTION
Closes https://github.com/kensho-technologies/babel-preset/issues/106.

~WIP. Won't continue until the upstream issue mentioned in the issue is resolved.~ A fix was released in `@babel/core@7.14.3`.

Adds a top-level `assumptions` field for all non-precompiled modules, and removes the `loose: true` default from the `@babel/preset-env` config. The former is a replacement for the latter. (Though not an exact replacement, so this is a breaking change. It's also breaking because passing `loose: false` no longer has any effect.)

The Kensho preset intentionally doesn't take an overriding `assumptions` option because it's a top-level config and can therefore be overridden by specifying them in the consumer config:

```json
{
  "presets": ["@kensho-technologies/babel-preset"],
  "assumptions": {"constantSuper": false}
}
```

The specific assumption settings are chosen to roughly match the previous behavior (trading off on absolute spec compliance for smaller/faster output) while smoothing over some rough edges. All assumptions are enabled except:

- `enumerableModuleMeta`: This is only used when transpiling to CJS, where output size is not a concern, so we might as well use a safer transform. We've actually had to work around this one in an internal test suite.
- `constantReexports`: Same as above.
- `iterableIsArray`: This combines `loose` in `transform-destructuring` and `transform-spread` (which we enabled) with `assumeArray` in `transform-for-of` (which we did not), so neither setting matches the previous behavior exactly. However, `loose` mode in `transform-spread` was the only optimization we found annoying in practice, because it prevented code like [this](https://babeljs.io/repl#?browsers=defaults&build=&builtIns=false&corejs=3.6&spec=false&loose=true&code_lz=MYewdgzgLgBBCmsC8MzwO4wMqIBQEoAoUSWAQwCcKyBPGFAbQDoWEoBdIA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.14.3&externalPlugins=) from working properly. So let's disable this assumption.
- `arrayLikeIsIterable`: This was not covered by `loose`, so let's start with it disabled to match. We rarely iterate over DOM collections where this would be useful.