### PR TITLE
Remove support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,11 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node: [12, 14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 14
       - run: npm install -g npm@7
       - uses: actions/cache@v2
         with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Closes #114.

Just a formality. This is generally considered a breaking change, so it should be merged right before the next major release. (But not sooner, in case we want to cut any minor/patch releases in the meantime.)