### PR TITLE
Group inline snapshot transform results by env

### DIFF
--- a/__tests__/modules.ts
+++ b/__tests__/modules.ts
@@ -9,25 +9,13 @@ test('static imports', () => {
     console.log(defaultExport, namedExport, namespace)
   `
 
-  expect(transform({code, env: 'development'})).toMatchInlineSnapshot(`
+  expect(transform({code})).toMatchInlineSnapshot(`
+    // development, production, esm:
     import defaultExport, {namedExport} from 'foo'
     import * as namespace from 'bar'
     console.log(defaultExport, namedExport, namespace)
-  `)
 
-  expect(transform({code, env: 'production'})).toMatchInlineSnapshot(`
-    import defaultExport, {namedExport} from 'foo'
-    import * as namespace from 'bar'
-    console.log(defaultExport, namedExport, namespace)
-  `)
-
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(`
-    import defaultExport, {namedExport} from 'foo'
-    import * as namespace from 'bar'
-    console.log(defaultExport, namedExport, namespace)
-  `)
-
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     var _foo = _interopRequireWildcard(require('foo'))
@@ -39,10 +27,11 @@ test('static imports', () => {
 test('dynamic imports', () => {
   const code = `import('foo')`
 
-  expect(transform({code, env: 'development'})).toMatchInlineSnapshot(`import('foo')`)
-  expect(transform({code, env: 'production'})).toMatchInlineSnapshot(`import('foo')`)
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(`import('foo')`)
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`
+  expect(transform({code})).toMatchInlineSnapshot(`
+    // development, production, esm:
+    import('foo')
+
+    // cjs:
     'use strict'
     var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault').default
     var _interopRequireWildcard2 = _interopRequireDefault(
@@ -61,33 +50,23 @@ test('static exports', () => {
     export * as baz from 'other'
   `
 
-  expect(transform({code, env: 'development'})).toMatchInlineSnapshot(`
+  expect(transform({code})).toMatchInlineSnapshot(`
+    // development, production:
     var foo = 1
     export default foo
     export {foo}
     export {bar} from 'other'
     import * as _baz from 'other'
     export {_baz as baz}
-  `)
 
-  expect(transform({code, env: 'production'})).toMatchInlineSnapshot(`
-    var foo = 1
-    export default foo
-    export {foo}
-    export {bar} from 'other'
-    import * as _baz from 'other'
-    export {_baz as baz}
-  `)
-
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(`
+    // esm:
     const foo = 1
     export default foo
     export {foo}
     export {bar} from 'other'
     export * as baz from 'other'
-  `)
 
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     Object.defineProperty(exports, '__esModule', {value: true})

--- a/__tests__/modules.ts
+++ b/__tests__/modules.ts
@@ -10,12 +10,12 @@ test('static imports', () => {
   `
 
   expect(transform({code})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     import defaultExport, {namedExport} from 'foo'
     import * as namespace from 'bar'
     console.log(defaultExport, namedExport, namespace)
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     var _foo = _interopRequireWildcard(require('foo'))
@@ -28,10 +28,10 @@ test('dynamic imports', () => {
   const code = `import('foo')`
 
   expect(transform({code})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     import('foo')
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault').default
     var _interopRequireWildcard2 = _interopRequireDefault(
@@ -51,7 +51,7 @@ test('static exports', () => {
   `
 
   expect(transform({code})).toMatchInlineSnapshot(`
-    // development, production:
+    // BABEL_ENV development, production:
     var foo = 1
     export default foo
     export {foo}
@@ -59,14 +59,14 @@ test('static exports', () => {
     import * as _baz from 'other'
     export {_baz as baz}
 
-    // esm:
+    // BABEL_ENV esm:
     const foo = 1
     export default foo
     export {foo}
     export {bar} from 'other'
     export * as baz from 'other'
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     Object.defineProperty(exports, '__esModule', {value: true})

--- a/__tests__/polyfills.ts
+++ b/__tests__/polyfills.ts
@@ -4,30 +4,34 @@ import transform from '../helpers/transform'
 
 test('removes polyfill imports in libraries', () => {
   const code = `import 'core-js/stable'`
+  const envs = ['esm', 'cjs']
 
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(``)
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`'use strict'`)
+  expect(transform({code, envs})).toMatchInlineSnapshot(`
+    // esm:
+
+    // cjs:
+    'use strict'
+  `)
 })
 
 test('narrows polyfill imports in apps with modern targets', () => {
   const code = `import 'core-js/stable'`
   const targets = 'Chrome 90'
+  const envs = ['development', 'production']
 
-  const development = transform({code, targets, env: 'development'})
-  const production = transform({code, targets, env: 'production'})
-  expect(development).toBe(production)
-  expect(development).toMatchInlineSnapshot(`import 'core-js/modules/web.immediate.js'`)
+  expect(transform({code, targets, envs})).toMatchInlineSnapshot(`
+    // development, production:
+    import 'core-js/modules/web.immediate.js'
+  `)
 })
 
 test('narrows polyfill imports in apps with legacy targets', () => {
   const code = `import 'core-js/stable'`
   const targets = 'Chrome 60'
+  const envs = ['development', 'production']
 
-  const development = transform({code, targets, env: 'development'})
-  const production = transform({code, targets, env: 'production'})
-  expect(development).toBe(production)
-
-  expect(development).toMatchInlineSnapshot(`
+  expect(transform({code, targets, envs})).toMatchInlineSnapshot(`
+    // development, production:
     import 'core-js/modules/es.symbol.description.js'
     import 'core-js/modules/es.symbol.async-iterator.js'
     import 'core-js/modules/es.array.flat.js'

--- a/__tests__/polyfills.ts
+++ b/__tests__/polyfills.ts
@@ -7,9 +7,9 @@ test('removes polyfill imports in libraries', () => {
   const envs = ['esm', 'cjs']
 
   expect(transform({code, envs})).toMatchInlineSnapshot(`
-    // esm:
+    // BABEL_ENV esm:
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
   `)
 })
@@ -20,7 +20,7 @@ test('narrows polyfill imports in apps with modern targets', () => {
   const envs = ['development', 'production']
 
   expect(transform({code, targets, envs})).toMatchInlineSnapshot(`
-    // development, production:
+    // BABEL_ENV development, production:
     import 'core-js/modules/web.immediate.js'
   `)
 })
@@ -31,7 +31,7 @@ test('narrows polyfill imports in apps with legacy targets', () => {
   const envs = ['development', 'production']
 
   expect(transform({code, targets, envs})).toMatchInlineSnapshot(`
-    // development, production:
+    // BABEL_ENV development, production:
     import 'core-js/modules/es.symbol.description.js'
     import 'core-js/modules/es.symbol.async-iterator.js'
     import 'core-js/modules/es.array.flat.js'

--- a/__tests__/react-classic.ts
+++ b/__tests__/react-classic.ts
@@ -17,7 +17,8 @@ test('transpiles JSX using classic runtime', () => {
     }
   `
 
-  expect(transform({code, options, env: 'development'})).toMatchInlineSnapshot(`
+  expect(transform({code, options})).toMatchInlineSnapshot(`
+    // development:
     var _jsxFileName = '/file.js',
       _s = $RefreshSig$()
     import * as React from 'react'
@@ -42,9 +43,8 @@ test('transpiles JSX using classic runtime', () => {
     _c = MyComponent
     var _c
     $RefreshReg$(_c, 'MyComponent')
-  `)
 
-  expect(transform({code, options, env: 'production'})).toMatchInlineSnapshot(`
+    // production:
     import * as React from 'react'
     function MyComponent() {
       React.useEffect(function () {}, [])
@@ -56,9 +56,8 @@ test('transpiles JSX using classic runtime', () => {
         ' bar'
       )
     }
-  `)
 
-  expect(transform({code, options, env: 'esm'})).toMatchInlineSnapshot(`
+    // esm:
     import * as React from 'react'
     function MyComponent() {
       React.useEffect(() => {}, [])
@@ -70,9 +69,8 @@ test('transpiles JSX using classic runtime', () => {
         ' bar'
       )
     }
-  `)
 
-  expect(transform({code, options, env: 'cjs'})).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     var React = _interopRequireWildcard(require('react'))

--- a/__tests__/react-classic.ts
+++ b/__tests__/react-classic.ts
@@ -18,7 +18,7 @@ test('transpiles JSX using classic runtime', () => {
   `
 
   expect(transform({code, options})).toMatchInlineSnapshot(`
-    // development:
+    // BABEL_ENV development:
     var _jsxFileName = '/file.js',
       _s = $RefreshSig$()
     import * as React from 'react'
@@ -44,7 +44,7 @@ test('transpiles JSX using classic runtime', () => {
     var _c
     $RefreshReg$(_c, 'MyComponent')
 
-    // production:
+    // BABEL_ENV production:
     import * as React from 'react'
     function MyComponent() {
       React.useEffect(function () {}, [])
@@ -57,7 +57,7 @@ test('transpiles JSX using classic runtime', () => {
       )
     }
 
-    // esm:
+    // BABEL_ENV esm:
     import * as React from 'react'
     function MyComponent() {
       React.useEffect(() => {}, [])
@@ -70,7 +70,7 @@ test('transpiles JSX using classic runtime', () => {
       )
     }
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _interopRequireWildcard = require('@babel/runtime/helpers/interopRequireWildcard').default
     var React = _interopRequireWildcard(require('react'))

--- a/__tests__/react.ts
+++ b/__tests__/react.ts
@@ -17,7 +17,7 @@ test('transpiles JSX', () => {
   `
 
   expect(transform({code})).toMatchInlineSnapshot(`
-    // development:
+    // BABEL_ENV development:
     var _jsxFileName = '/file.js',
       _s = $RefreshSig$()
     import {useState} from 'react'
@@ -52,7 +52,7 @@ test('transpiles JSX', () => {
     var _c
     $RefreshReg$(_c, 'MyComponent')
 
-    // production:
+    // BABEL_ENV production:
     import {useState} from 'react'
     import {jsx as _jsx} from 'react/jsx-runtime'
     import {jsxs as _jsxs} from 'react/jsx-runtime'
@@ -64,7 +64,7 @@ test('transpiles JSX', () => {
       )
     }
 
-    // esm:
+    // BABEL_ENV esm:
     import {useState} from 'react'
     import {jsx as _jsx} from 'react/jsx-runtime'
     import {jsxs as _jsxs} from 'react/jsx-runtime'
@@ -77,7 +77,7 @@ test('transpiles JSX', () => {
       })
     }
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _react = require('react')
     var _jsxRuntime = require('react/jsx-runtime')

--- a/__tests__/react.ts
+++ b/__tests__/react.ts
@@ -16,7 +16,8 @@ test('transpiles JSX', () => {
     }
   `
 
-  expect(transform({code, env: 'development'})).toMatchInlineSnapshot(`
+  expect(transform({code})).toMatchInlineSnapshot(`
+    // development:
     var _jsxFileName = '/file.js',
       _s = $RefreshSig$()
     import {useState} from 'react'
@@ -50,9 +51,8 @@ test('transpiles JSX', () => {
     _c = MyComponent
     var _c
     $RefreshReg$(_c, 'MyComponent')
-  `)
 
-  expect(transform({code, env: 'production'})).toMatchInlineSnapshot(`
+    // production:
     import {useState} from 'react'
     import {jsx as _jsx} from 'react/jsx-runtime'
     import {jsxs as _jsxs} from 'react/jsx-runtime'
@@ -63,9 +63,8 @@ test('transpiles JSX', () => {
         Object.assign({height: 2}, rest, {children: [/*#__PURE__*/ _jsx('div', {}), 'foo', ' bar']})
       )
     }
-  `)
 
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(`
+    // esm:
     import {useState} from 'react'
     import {jsx as _jsx} from 'react/jsx-runtime'
     import {jsxs as _jsxs} from 'react/jsx-runtime'
@@ -77,9 +76,8 @@ test('transpiles JSX', () => {
         children: [/*#__PURE__*/ _jsx('div', {}), 'foo', ' bar'],
       })
     }
-  `)
 
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     var _react = require('react')
     var _jsxRuntime = require('react/jsx-runtime')

--- a/__tests__/runtime.ts
+++ b/__tests__/runtime.ts
@@ -9,13 +9,13 @@ test('imports external runtime helpers by default', () => {
   const options = {targets}
 
   expect(transform({code, options})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     import _objectWithoutPropertiesLoose from '@babel/runtime/helpers/objectWithoutPropertiesLoose'
     var _obj = obj,
       foo = _obj.foo,
       rest = _objectWithoutPropertiesLoose(_obj, ['foo'])
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault').default
     var _objectWithoutPropertiesLoose2 = _interopRequireDefault(
@@ -31,7 +31,7 @@ test('injects runtime helpers when `runtime` is disabled', () => {
   const options = {targets, runtime: false}
 
   expect(transform({code, options})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {}
       var target = {}
@@ -48,7 +48,7 @@ test('injects runtime helpers when `runtime` is disabled', () => {
       foo = _obj.foo,
       rest = _objectWithoutPropertiesLoose(_obj, ['foo'])
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {}

--- a/__tests__/runtime.ts
+++ b/__tests__/runtime.ts
@@ -7,22 +7,15 @@ const targets = 'IE 11' // ensures that a helper is required to transpile the re
 
 test('imports external runtime helpers by default', () => {
   const options = {targets}
-  const development = transform({code, options, env: 'development'})
-  const production = transform({code, options, env: 'production'})
-  const esm = transform({code, options, env: 'esm'})
-  const cjs = transform({code, options, env: 'cjs'})
 
-  expect(development).toMatchInlineSnapshot(`
+  expect(transform({code, options})).toMatchInlineSnapshot(`
+    // development, production, esm:
     import _objectWithoutPropertiesLoose from '@babel/runtime/helpers/objectWithoutPropertiesLoose'
     var _obj = obj,
       foo = _obj.foo,
       rest = _objectWithoutPropertiesLoose(_obj, ['foo'])
-  `)
 
-  expect(production).toBe(development)
-  expect(esm).toBe(development)
-
-  expect(cjs).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     var _interopRequireDefault = require('@babel/runtime/helpers/interopRequireDefault').default
     var _objectWithoutPropertiesLoose2 = _interopRequireDefault(
@@ -36,12 +29,9 @@ test('imports external runtime helpers by default', () => {
 
 test('injects runtime helpers when `runtime` is disabled', () => {
   const options = {targets, runtime: false}
-  const development = transform({code, options, env: 'development'})
-  const production = transform({code, options, env: 'production'})
-  const esm = transform({code, options, env: 'esm'})
-  const cjs = transform({code, options, env: 'cjs'})
 
-  expect(development).toMatchInlineSnapshot(`
+  expect(transform({code, options})).toMatchInlineSnapshot(`
+    // development, production, esm:
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {}
       var target = {}
@@ -57,12 +47,8 @@ test('injects runtime helpers when `runtime` is disabled', () => {
     var _obj = obj,
       foo = _obj.foo,
       rest = _objectWithoutPropertiesLoose(_obj, ['foo'])
-  `)
 
-  expect(production).toBe(development)
-  expect(esm).toBe(development)
-
-  expect(cjs).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {}

--- a/__tests__/syntax.ts
+++ b/__tests__/syntax.ts
@@ -13,7 +13,8 @@ test('class properties', () => {
     }
   `
 
-  expect(transform({code, env: 'development'})).toMatchInlineSnapshot(`
+  expect(transform({code})).toMatchInlineSnapshot(`
+    // development, production:
     import _classPrivateFieldLooseKey from '@babel/runtime/helpers/classPrivateFieldLooseKey'
     var _privateMethod = /*#__PURE__*/ _classPrivateFieldLooseKey('privateMethod')
     var Foo = function Foo() {
@@ -26,9 +27,8 @@ test('class properties', () => {
       return 1
     }
     Foo.bar = 'abc'
-  `)
 
-  expect(transform({code, env: 'esm'})).toMatchInlineSnapshot(`
+    // esm:
     class Foo {
       static bar = 'abc'
       baz = (x, y) => x({...y})
@@ -36,9 +36,8 @@ test('class properties', () => {
         return 1
       }
     }
-  `)
 
-  expect(transform({code, env: 'cjs'})).toMatchInlineSnapshot(`
+    // cjs:
     'use strict'
     class Foo {
       static bar = 'abc'

--- a/__tests__/syntax.ts
+++ b/__tests__/syntax.ts
@@ -14,7 +14,7 @@ test('class properties', () => {
   `
 
   expect(transform({code})).toMatchInlineSnapshot(`
-    // development, production:
+    // BABEL_ENV development, production:
     import _classPrivateFieldLooseKey from '@babel/runtime/helpers/classPrivateFieldLooseKey'
     var _privateMethod = /*#__PURE__*/ _classPrivateFieldLooseKey('privateMethod')
     var Foo = function Foo() {
@@ -28,7 +28,7 @@ test('class properties', () => {
     }
     Foo.bar = 'abc'
 
-    // esm:
+    // BABEL_ENV esm:
     class Foo {
       static bar = 'abc'
       baz = (x, y) => x({...y})
@@ -37,7 +37,7 @@ test('class properties', () => {
       }
     }
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     class Foo {
       static bar = 'abc'

--- a/__tests__/typescript.ts
+++ b/__tests__/typescript.ts
@@ -7,10 +7,10 @@ test('strips type annotations in .ts files', () => {
   const filename = 'file.ts'
 
   expect(transform({code, filename})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     var one = 1
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var one = 1
   `)
@@ -21,10 +21,10 @@ test('strips type annotations in .tsx files', () => {
   const filename = 'file.tsx'
 
   expect(transform({code, filename})).toMatchInlineSnapshot(`
-    // development, production, esm:
+    // BABEL_ENV development, production, esm:
     var one = 1
 
-    // cjs:
+    // BABEL_ENV cjs:
     'use strict'
     var one = 1
   `)

--- a/__tests__/typescript.ts
+++ b/__tests__/typescript.ts
@@ -3,26 +3,28 @@ import {test, expect} from '@jest/globals'
 import transform from '../helpers/transform'
 
 test('strips type annotations in .ts files', () => {
-  const filename = 'file.ts'
   const code = `var one: number = 1`
+  const filename = 'file.ts'
 
-  expect(transform({code, filename, env: 'development'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'production'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'esm'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'cjs'})).toMatchInlineSnapshot(`
+  expect(transform({code, filename})).toMatchInlineSnapshot(`
+    // development, production, esm:
+    var one = 1
+
+    // cjs:
     'use strict'
     var one = 1
   `)
 })
 
 test('strips type annotations in .tsx files', () => {
-  const filename = 'file.tsx'
   const code = `var one: number = 1`
+  const filename = 'file.tsx'
 
-  expect(transform({code, filename, env: 'development'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'production'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'esm'})).toMatchInlineSnapshot(`var one = 1`)
-  expect(transform({code, filename, env: 'cjs'})).toMatchInlineSnapshot(`
+  expect(transform({code, filename})).toMatchInlineSnapshot(`
+    // development, production, esm:
+    var one = 1
+
+    // cjs:
     'use strict'
     var one = 1
   `)

--- a/helpers/groupBy.ts
+++ b/helpers/groupBy.ts
@@ -1,0 +1,12 @@
+export default function groupBy<T, K>(items: T[], iteratee: (item: T) => K): Map<K, T[]> {
+  const groups = new Map<K, T[]>()
+
+  items.forEach((item) => {
+    const key = iteratee(item)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (groups.has(key)) groups.get(key)!.push(item)
+    else groups.set(key, [item])
+  })
+
+  return groups
+}

--- a/helpers/serializer.ts
+++ b/helpers/serializer.ts
@@ -1,10 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import {format, resolveConfig} from 'prettier'
-
-const prettierConfig = resolveConfig.sync(__dirname)
-if (!prettierConfig) throw new Error()
-
 module.exports = {
   test: (val: string) => typeof val === 'string',
-  serialize: (val: string) => format(val, {...prettierConfig, parser: 'babel'}).trim(),
+  serialize: (val: string) => val,
 }
+
+export {}

--- a/helpers/transform.ts
+++ b/helpers/transform.ts
@@ -43,6 +43,6 @@ export default function transform(config: TransformConfig): string {
 
   // return a string containing each env group and its transform result
   return [...resultGroups]
-    .map((group) => `// ${group[1].join(', ')}:\n${group[0]}`.trim())
+    .map((group) => `// BABEL_ENV ${group[1].join(', ')}:\n${group[0]}`.trim())
     .join('\n\n')
 }

--- a/helpers/transform.ts
+++ b/helpers/transform.ts
@@ -1,25 +1,48 @@
 import {transformSync} from '@babel/core'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {format, resolveConfig} from 'prettier'
 
 import preset from '..'
 
+import groupBy from './groupBy'
+
+const prettierConfig = resolveConfig.sync(__dirname)
+if (!prettierConfig) throw new Error()
+
 interface TransformConfig {
   code: string
-  env: string
+  envs?: string[]
   filename?: string
   options?: Record<string, unknown>
   targets?: string
 }
 
-export default function transform(config: TransformConfig): string | undefined {
-  const {code, env, filename = 'file.js', options, ...rest} = config
-  const result = transformSync(code, {
-    envName: env,
-    presets: [[preset, options]],
-    filename: `/${filename}`,
-    babelrc: false,
-    compact: true,
-    ...rest,
+const defaultEnvs = ['development', 'production', 'esm', 'cjs']
+
+/**
+ * Transforms input code using the Babel preset. Supports additional configuration, including a list of Babel envs.
+ *
+ * @returns A string containing the transform results, grouped by Babel env.
+ */
+export default function transform(config: TransformConfig): string {
+  const {code, envs = defaultEnvs, filename = 'file.js', options, ...rest} = config
+
+  // transform the input using each env, and group the envs by the result
+  const resultGroups = groupBy(envs, (env) => {
+    const result = transformSync(code, {
+      envName: env,
+      presets: [[preset, options]],
+      filename: `/${filename}`,
+      babelrc: false,
+      compact: true,
+      ...rest,
+    })
+    if (typeof result?.code !== 'string') throw new Error()
+    return format(result.code, {...prettierConfig, parser: 'babel'}).trim()
   })
-  if (typeof result?.code !== 'string') throw new Error()
-  return result.code
+
+  // return a string containing each env group and its transform result
+  return [...resultGroups]
+    .map((group) => `// ${group[1].join(', ')}:\n${group[0]}`.trim())
+    .join('\n\n')
 }


### PR DESCRIPTION
Slightly different, less polished approach to https://github.com/kensho-technologies/babel-preset/pull/117.

Not sure if this is worth the additional layer of abstraction, but it solves a few problems in that PR:
- Every test by default has to remember to add an assertion for each env. It would be easy to miss one, especially if the snapshots are too large to all fit on one screen. This approach defaults to transpiling for every env.
- There's no easy way to tell whether two envs produce the same transpilation result without a close comparison. It's easy to miss subtle differences. This solves that by grouping envs that product the same result. It could also be solved by doing `expect(env1Output).toBe(env2Output)` but we don't necessarily want to declare as an assertion that these should _always_ be the same, we just want to know if they are and when that changes.