### PR TITLE
Remove modern envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,15 @@ You can set up Babel transpilation in [several ways](http://babeljs.io/docs/setu
 
 The preset can be configured using several options. Note that some options' defaults depend on the [Babel environment](https://babeljs.io/docs/en/options#envname), which may be one of the following:
 
-| Environment          | Purpose                                                              |
-| -------------------- | -------------------------------------------------------------------- |
-| `development`        | Transpiling an app for development.                                  |
-| `production`         | Transpiling an app for production.                                   |
-| `development-modern` | Transpiling an app for development with only modern browser support. |
-| `production-modern`  | Transpiling an app for production with only modern browser support.  |
-| `test`               | Transpiling an app or library to run in the current version of Node. |
-| `cjs`                | Transpiling a library for distribution as CJS.                       |
-| `esm`                | Transpiling a library for distribution as ESM.                       |
+| Environment   | Purpose                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `development` | Transpiling an app for development.                                  |
+| `production`  | Transpiling an app for production.                                   |
+| `test`        | Transpiling an app or library to run in the current version of Node. |
+| `cjs`         | Transpiling a library for distribution as CJS.                       |
+| `esm`         | Transpiling a library for distribution as ESM.                       |
 
 The present extends [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env), and forwards all additional options to that preset.
-
-Browser support is provided by `@babel/preset-env`'s [`browserslist` integration](https://babeljs.io/docs/en/babel-preset-env#browserslist-integration), where browser support is declared in a `.browserslistrc` file which can either contain a single set of browser queries or [multiple named groups of queries](https://github.com/browserslist/browserslist#configuring-for-different-environments). This preset's `development` and `production` envs will use the default (`production`) group while the `development-modern` and `production-modern` envs will use a `modern` group. Be sure to specify these groups if using the corresponding environments.
-
-### `browserslistEnv`
-
-`string` | `undefined`<br />
-Default: `modern` for `development-modern` and `production-modern` envs, `undefined` otherwise
-
-The Browserslist environment to use. Forwarded to [the corresponding option in `@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#browserslistenv).
 
 ### `emotion`
 

--- a/__snapshots__/test.ts.snap
+++ b/__snapshots__/test.ts.snap
@@ -13,13 +13,22 @@ exports[`avoids transpiling known precompiled packages given {}, {}: output (cjs
 
 exports[`avoids transpiling known precompiled packages given {}, {}: output (development) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}, {}: output (development-modern) 1`] = `export default class React{method(value){return value??2;}}`;
-
 exports[`avoids transpiling known precompiled packages given {}, {}: output (esm) 1`] = `export default class React{method(value){return value??2;}}`;
 
 exports[`avoids transpiling known precompiled packages given {}, {}: output (production) 1`] = `export default class React{method(value){return value??2;}}`;
 
-exports[`avoids transpiling known precompiled packages given {}, {}: output (production-modern) 1`] = `export default class React{method(value){return value??2;}}`;
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {"targets":"Chrome 88"}: input 1`] = `
+import 'core-js/stable'
+
+`;
+
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {"targets":"Chrome 88"}: output (cjs) 1`] = `"use strict";`;
+
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {"targets":"Chrome 88"}: output (development) 1`] = `import "core-js/modules/web.immediate.js";`;
+
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {"targets":"Chrome 88"}: output (esm) 1`] = ``;
+
+exports[`replaces generic polyfill with env-targeted polyfills given {}, {"targets":"Chrome 88"}: output (production) 1`] = `import "core-js/modules/web.immediate.js";`;
 
 exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: input 1`] = `
 import 'core-js/stable'
@@ -239,8 +248,6 @@ import "core-js/modules/web.url.to-json.js";
 import "core-js/modules/web.url-search-params.js";
 `;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (development-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
-
 exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (esm) 1`] = ``;
 
 exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (production) 1`] = `
@@ -454,8 +461,6 @@ import "core-js/modules/web.url.to-json.js";
 import "core-js/modules/web.url-search-params.js";
 `;
 
-exports[`replaces generic polyfill with env-targeted polyfills given {}, {}: output (production-modern) 1`] = `import "core-js/modules/web.immediate.js";`;
-
 exports[`transpiles CJS in node_modules given {}, {}: input 1`] = `
 module.exports = function forEach(array, sideEffect) {
   for (const value of array) sideEffect(value)
@@ -467,13 +472,9 @@ exports[`transpiles CJS in node_modules given {}, {}: output (cjs) 1`] = `module
 
 exports[`transpiles CJS in node_modules given {}, {}: output (development) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
 
-exports[`transpiles CJS in node_modules given {}, {}: output (development-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
-
 exports[`transpiles CJS in node_modules given {}, {}: output (esm) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
 exports[`transpiles CJS in node_modules given {}, {}: output (production) 1`] = `var _createForOfIteratorHelperLoose=require("@babel/runtime/helpers/createForOfIteratorHelperLoose")["default"];module.exports=function forEach(array,sideEffect){for(var _iterator=_createForOfIteratorHelperLoose(array),_step;!(_step=_iterator()).done;){var value=_step.value;sideEffect(value);}};`;
-
-exports[`transpiles CJS in node_modules given {}, {}: output (production-modern) 1`] = `module.exports=function forEach(array,sideEffect){for(const value of array)sideEffect(value);};`;
 
 exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: input 1`] = `
 import defaultImport, {namedImport} from 'foo'
@@ -692,80 +693,6 @@ var _default = obj;
 exports["default"] = _default;
 `;
 
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (development-modern) 1`] = `
-"use strict";
-
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
-
-var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.obj = exports.default = void 0;
-
-var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
-
-var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
-
-var _foo = _interopRequireWildcard3(require("foo"));
-
-var namespaceImport = _interopRequireWildcard3(require("bar"));
-
-var _nullishAssignment;
-
-const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
-
-var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2.default)("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-exports.obj = obj;
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-var _default = obj;
-exports.default = _default;
-`;
-
 exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (esm) 1`] = `
 "use strict";
 
@@ -943,80 +870,6 @@ var nullishCoalescing = obj != null ? obj : 1;
 var optionalChaining = obj == null ? void 0 : obj.b;
 var _default = obj;
 exports["default"] = _default;
-`;
-
-exports[`transpiles ES2020+ syntax given {"modules":"commonjs"}, {}: output (production-modern) 1`] = `
-"use strict";
-
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
-
-var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.obj = exports.default = void 0;
-
-var _classPrivateFieldLooseKey2 = _interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));
-
-var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
-
-var _foo = _interopRequireWildcard3(require("foo"));
-
-var namespaceImport = _interopRequireWildcard3(require("bar"));
-
-var _nullishAssignment;
-
-const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
-
-var _privateMethod = /*#__PURE__*/(0, _classPrivateFieldLooseKey2.default)("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-exports.obj = obj;
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-var _default = obj;
-exports.default = _default;
 `;
 
 exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: input 1`] = `
@@ -1218,66 +1071,6 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (development-modern) 1`] = `
-var _nullishAssignment;
-
-var id = 0;
-
-function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
 exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
@@ -1421,442 +1214,6 @@ var nullishAssignment;
 (_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
 var nullishCoalescing = obj != null ? obj : 1;
 var optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"runtime":false}, {}: output (production-modern) 1`] = `
-var _nullishAssignment;
-
-var id = 0;
-
-function _classPrivateFieldLooseKey(name) { return "__private_" + id++ + "_" + name; }
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: input 1`] = `
-import defaultImport, {namedImport} from 'foo'
-import * as namespaceImport from 'bar'
-
-const dynamicImport = import('baz')
-
-class Foo {
-  static bar = 'abc'
-  baz = (x, y) => x({...y})
-  #privateMethod() {
-    return 1
-  }
-}
-
-function* infiniteGenerator() {
-  yield 1
-  yield* infiniteGenerator()
-}
-
-async function asyncFunction() {
-  return await null
-}
-
-const obj = {a: 1, b: 2}
-
-const spread = {...obj, b: 2, c: 3}
-const {a, ...rest} = spread
-
-let nullishAssignment
-nullishAssignment ??= 1
-const nullishCoalescing = obj ?? 1
-const optionalChaining = obj?.b
-
-export default obj
-export {obj}
-
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (cjs) 1`] = `
-"use strict";
-
-var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
-
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.obj = exports.default = void 0;
-
-var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
-
-var _foo = _interopRequireWildcard3(require("foo"));
-
-var namespaceImport = _interopRequireWildcard3(require("bar"));
-
-const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
-
-class Foo {
-  static bar = 'abc';
-  baz = (x, y) => x({ ...y
-  });
-
-  #privateMethod() {
-    return 1;
-  }
-
-}
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-exports.obj = obj;
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-nullishAssignment ??= 1;
-const nullishCoalescing = obj ?? 1;
-const optionalChaining = obj?.b;
-var _default = obj;
-exports.default = _default;
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (development) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (development-modern) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (esm) 1`] = `
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-class Foo {
-  static bar = 'abc';
-  baz = (x, y) => x({ ...y
-  });
-
-  #privateMethod() {
-    return 1;
-  }
-
-}
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-nullishAssignment ??= 1;
-const nullishCoalescing = obj ?? 1;
-const optionalChaining = obj?.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (production) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
-exports[`transpiles ES2020+ syntax given {"targets":"Chrome 88"}, {}: output (production-modern) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
 export default obj;
 export { obj };
 `;
@@ -2056,64 +1413,6 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (development-modern) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
 exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
@@ -2257,7 +1556,209 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}, {"assumptions":{"enumerableModuleMeta":true}}: output (production-modern) 1`] = `
+exports[`transpiles ES2020+ syntax given {}, {"targets":"Chrome 88"}: input 1`] = `
+import defaultImport, {namedImport} from 'foo'
+import * as namespaceImport from 'bar'
+
+const dynamicImport = import('baz')
+
+class Foo {
+  static bar = 'abc'
+  baz = (x, y) => x({...y})
+  #privateMethod() {
+    return 1
+  }
+}
+
+function* infiniteGenerator() {
+  yield 1
+  yield* infiniteGenerator()
+}
+
+async function asyncFunction() {
+  return await null
+}
+
+const obj = {a: 1, b: 2}
+
+const spread = {...obj, b: 2, c: 3}
+const {a, ...rest} = spread
+
+let nullishAssignment
+nullishAssignment ??= 1
+const nullishCoalescing = obj ?? 1
+const optionalChaining = obj?.b
+
+export default obj
+export {obj}
+
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {"targets":"Chrome 88"}: output (cjs) 1`] = `
+"use strict";
+
+var _interopRequireWildcard3 = require("@babel/runtime/helpers/interopRequireWildcard").default;
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault").default;
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.obj = exports.default = void 0;
+
+var _interopRequireWildcard2 = _interopRequireDefault(require("@babel/runtime/helpers/interopRequireWildcard"));
+
+var _foo = _interopRequireWildcard3(require("foo"));
+
+var namespaceImport = _interopRequireWildcard3(require("bar"));
+
+const dynamicImport = Promise.resolve().then(() => (0, _interopRequireWildcard2.default)(require('baz')));
+
+class Foo {
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
+
+  #privateMethod() {
+    return 1;
+  }
+
+}
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+exports.obj = obj;
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+nullishAssignment ?? (nullishAssignment = 1);
+const nullishCoalescing = obj ?? 1;
+const optionalChaining = obj?.b;
+var _default = obj;
+exports.default = _default;
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {"targets":"Chrome 88"}: output (development) 1`] = `
+import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
+
+var _nullishAssignment;
+
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+const dynamicImport = import('baz');
+
+var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
+
+class Foo {
+  constructor() {
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
+    });
+
+    this.baz = (x, y) => x({ ...y
+    });
+  }
+
+}
+
+function _privateMethod2() {
+  return 1;
+}
+
+Foo.bar = 'abc';
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
+const nullishCoalescing = obj != null ? obj : 1;
+const optionalChaining = obj == null ? void 0 : obj.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {"targets":"Chrome 88"}: output (esm) 1`] = `
+import defaultImport, { namedImport } from 'foo';
+import * as namespaceImport from 'bar';
+const dynamicImport = import('baz');
+
+class Foo {
+  static bar = 'abc';
+  baz = (x, y) => x({ ...y
+  });
+
+  #privateMethod() {
+    return 1;
+  }
+
+}
+
+function* infiniteGenerator() {
+  yield 1;
+  yield* infiniteGenerator();
+}
+
+async function asyncFunction() {
+  return await null;
+}
+
+const obj = {
+  a: 1,
+  b: 2
+};
+const spread = { ...obj,
+  b: 2,
+  c: 3
+};
+const {
+  a,
+  ...rest
+} = spread;
+let nullishAssignment;
+nullishAssignment ?? (nullishAssignment = 1);
+const nullishCoalescing = obj ?? 1;
+const optionalChaining = obj?.b;
+export default obj;
+export { obj };
+`;
+
+exports[`transpiles ES2020+ syntax given {}, {"targets":"Chrome 88"}: output (production) 1`] = `
 import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
 
 var _nullishAssignment;
@@ -2512,64 +2013,6 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}, {}: output (development-modern) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
 exports[`transpiles ES2020+ syntax given {}, {}: output (esm) 1`] = `
 import defaultImport, { namedImport } from 'foo';
 import * as namespaceImport from 'bar';
@@ -2713,64 +2156,6 @@ export default obj;
 export { obj };
 `;
 
-exports[`transpiles ES2020+ syntax given {}, {}: output (production-modern) 1`] = `
-import _classPrivateFieldLooseKey from "@babel/runtime/helpers/classPrivateFieldLooseKey";
-
-var _nullishAssignment;
-
-import defaultImport, { namedImport } from 'foo';
-import * as namespaceImport from 'bar';
-const dynamicImport = import('baz');
-
-var _privateMethod = /*#__PURE__*/_classPrivateFieldLooseKey("privateMethod");
-
-class Foo {
-  constructor() {
-    Object.defineProperty(this, _privateMethod, {
-      value: _privateMethod2
-    });
-
-    this.baz = (x, y) => x({ ...y
-    });
-  }
-
-}
-
-function _privateMethod2() {
-  return 1;
-}
-
-Foo.bar = 'abc';
-
-function* infiniteGenerator() {
-  yield 1;
-  yield* infiniteGenerator();
-}
-
-async function asyncFunction() {
-  return await null;
-}
-
-const obj = {
-  a: 1,
-  b: 2
-};
-const spread = { ...obj,
-  b: 2,
-  c: 3
-};
-const {
-  a,
-  ...rest
-} = spread;
-let nullishAssignment;
-(_nullishAssignment = nullishAssignment) != null ? _nullishAssignment : nullishAssignment = 1;
-const nullishCoalescing = obj != null ? obj : 1;
-const optionalChaining = obj == null ? void 0 : obj.b;
-export default obj;
-export { obj };
-`;
-
 exports[`transpiles ESM in node_modules given {}, {}: input 1`] = `
 export function map(value) {
   return value ?? 2
@@ -2782,13 +2167,9 @@ exports[`transpiles ESM in node_modules given {}, {}: output (cjs) 1`] = `"use s
 
 exports[`transpiles ESM in node_modules given {}, {}: output (development) 1`] = `export function map(value){return value!=null?value:2;}`;
 
-exports[`transpiles ESM in node_modules given {}, {}: output (development-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
-
 exports[`transpiles ESM in node_modules given {}, {}: output (esm) 1`] = `export function map(value){return value??2;}`;
 
 exports[`transpiles ESM in node_modules given {}, {}: output (production) 1`] = `export function map(value){return value!=null?value:2;}`;
-
-exports[`transpiles ESM in node_modules given {}, {}: output (production-modern) 1`] = `export function map(value){return value!=null?value:2;}`;
 
 exports[`transpiles Emotion given {"emotion":true}, {}: input 1`] = `
 import {useState} from 'react'
@@ -2948,75 +2329,6 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion given {"emotion":true}, {}: output (development-modern) 1`] = `
-var _jsxFileName = "/emotion.js",
-    _s = $RefreshSig$();
-
-function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
-
-import { useState } from 'react';
-import { css } from '@emotion/react';
-import { jsxDEV as _jsxDEV } from "@emotion/react/jsx-dev-runtime";
-import { Fragment as _Fragment } from "@emotion/react/jsx-dev-runtime";
-const cssObj = process.env.NODE_ENV === "production" ? {
-  name: "hwfcu5",
-  styles: "color:red"
-} : {
-  name: "aslxie-cssObj",
-  styles: "color:red;label:cssObj;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR2UiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7dXNlU3RhdGV9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHtjc3N9IGZyb20gJ0BlbW90aW9uL3JlYWN0J1xuXG5jb25zdCBjc3NPYmogPSBjc3Moe2NvbG9yOiAncmVkJ30pXG5cbmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIE15Q29tcG9uZW50KHByb3BzKSB7XG4gIGNvbnN0IHthLCBiLCAuLi5yZXN0fSA9IHByb3BzXG4gIGNvbnN0IFtjb3VudCwgc2V0Q291bnRdID0gdXNlU3RhdGUoMClcbiAgcmV0dXJuIChcbiAgICA8PlxuICAgICAgPGJ1dHRvbiBjc3M9e3tjb2xvcjogJ2JsdWUnfX0gb25DbGljaz17KCkgPT4gc2V0Q291bnQoKHByZXZTaXplKSA9PiBwcmV2U2l6ZSArIDEpfT5cbiAgICAgICAgSW5jcmVtZW50XG4gICAgICA8L2J1dHRvbj5cbiAgICAgIDxkaXYgaGVpZ2h0PXtjb3VudH0gey4uLnJlc3R9IGNzcz17Y3NzT2JqfSAvPlxuICAgIDwvPlxuICApXG59XG4iXX0= */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-var _ref = process.env.NODE_ENV === "production" ? {
-  name: "117wnve",
-  styles: "color:blue"
-} : {
-  name: "fveiva-MyComponent",
-  styles: "color:blue;label:MyComponent;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBVWMiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7dXNlU3RhdGV9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHtjc3N9IGZyb20gJ0BlbW90aW9uL3JlYWN0J1xuXG5jb25zdCBjc3NPYmogPSBjc3Moe2NvbG9yOiAncmVkJ30pXG5cbmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIE15Q29tcG9uZW50KHByb3BzKSB7XG4gIGNvbnN0IHthLCBiLCAuLi5yZXN0fSA9IHByb3BzXG4gIGNvbnN0IFtjb3VudCwgc2V0Q291bnRdID0gdXNlU3RhdGUoMClcbiAgcmV0dXJuIChcbiAgICA8PlxuICAgICAgPGJ1dHRvbiBjc3M9e3tjb2xvcjogJ2JsdWUnfX0gb25DbGljaz17KCkgPT4gc2V0Q291bnQoKHByZXZTaXplKSA9PiBwcmV2U2l6ZSArIDEpfT5cbiAgICAgICAgSW5jcmVtZW50XG4gICAgICA8L2J1dHRvbj5cbiAgICAgIDxkaXYgaGVpZ2h0PXtjb3VudH0gey4uLnJlc3R9IGNzcz17Y3NzT2JqfSAvPlxuICAgIDwvPlxuICApXG59XG4iXX0= */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-export default function MyComponent(props) {
-  _s();
-
-  const {
-    a,
-    b,
-    ...rest
-  } = props;
-  const [count, setCount] = useState(0);
-  return _jsxDEV(_Fragment, {
-    children: [_jsxDEV("button", {
-      css: _ref,
-      onClick: () => setCount(prevSize => prevSize + 1),
-      children: "Increment"
-    }, void 0, false, {
-      fileName: _jsxFileName,
-      lineNumber: 11,
-      columnNumber: 7
-    }, this), _jsxDEV("div", {
-      height: count,
-      ...rest,
-      css: cssObj
-    }, void 0, false, {
-      fileName: _jsxFileName,
-      lineNumber: 14,
-      columnNumber: 7
-    }, this)]
-  }, void 0, true);
-}
-
-_s(MyComponent, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");
-
-_c = MyComponent;
-
-var _c;
-
-$RefreshReg$(_c, "MyComponent");
-`;
-
 exports[`transpiles Emotion given {"emotion":true}, {}: output (esm) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
@@ -3122,55 +2434,6 @@ export default function MyComponent(props) {
     }, rest, {
       css: cssObj
     }))]
-  });
-}
-`;
-
-exports[`transpiles Emotion given {"emotion":true}, {}: output (production-modern) 1`] = `
-function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
-
-import { useState } from 'react';
-import { css } from '@emotion/react';
-import { jsx as _jsx } from "@emotion/react/jsx-runtime";
-import { Fragment as _Fragment } from "@emotion/react/jsx-runtime";
-import { jsxs as _jsxs } from "@emotion/react/jsx-runtime";
-const cssObj = process.env.NODE_ENV === "production" ? {
-  name: "hwfcu5",
-  styles: "color:red"
-} : {
-  name: "aslxie-cssObj",
-  styles: "color:red;label:cssObj;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR2UiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7dXNlU3RhdGV9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHtjc3N9IGZyb20gJ0BlbW90aW9uL3JlYWN0J1xuXG5jb25zdCBjc3NPYmogPSBjc3Moe2NvbG9yOiAncmVkJ30pXG5cbmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIE15Q29tcG9uZW50KHByb3BzKSB7XG4gIGNvbnN0IHthLCBiLCAuLi5yZXN0fSA9IHByb3BzXG4gIGNvbnN0IFtjb3VudCwgc2V0Q291bnRdID0gdXNlU3RhdGUoMClcbiAgcmV0dXJuIChcbiAgICA8PlxuICAgICAgPGJ1dHRvbiBjc3M9e3tjb2xvcjogJ2JsdWUnfX0gb25DbGljaz17KCkgPT4gc2V0Q291bnQoKHByZXZTaXplKSA9PiBwcmV2U2l6ZSArIDEpfT5cbiAgICAgICAgSW5jcmVtZW50XG4gICAgICA8L2J1dHRvbj5cbiAgICAgIDxkaXYgaGVpZ2h0PXtjb3VudH0gey4uLnJlc3R9IGNzcz17Y3NzT2JqfSAvPlxuICAgIDwvPlxuICApXG59XG4iXX0= */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-var _ref = process.env.NODE_ENV === "production" ? {
-  name: "117wnve",
-  styles: "color:blue"
-} : {
-  name: "fveiva-MyComponent",
-  styles: "color:blue;label:MyComponent;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBVWMiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7dXNlU3RhdGV9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHtjc3N9IGZyb20gJ0BlbW90aW9uL3JlYWN0J1xuXG5jb25zdCBjc3NPYmogPSBjc3Moe2NvbG9yOiAncmVkJ30pXG5cbmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIE15Q29tcG9uZW50KHByb3BzKSB7XG4gIGNvbnN0IHthLCBiLCAuLi5yZXN0fSA9IHByb3BzXG4gIGNvbnN0IFtjb3VudCwgc2V0Q291bnRdID0gdXNlU3RhdGUoMClcbiAgcmV0dXJuIChcbiAgICA8PlxuICAgICAgPGJ1dHRvbiBjc3M9e3tjb2xvcjogJ2JsdWUnfX0gb25DbGljaz17KCkgPT4gc2V0Q291bnQoKHByZXZTaXplKSA9PiBwcmV2U2l6ZSArIDEpfT5cbiAgICAgICAgSW5jcmVtZW50XG4gICAgICA8L2J1dHRvbj5cbiAgICAgIDxkaXYgaGVpZ2h0PXtjb3VudH0gey4uLnJlc3R9IGNzcz17Y3NzT2JqfSAvPlxuICAgIDwvPlxuICApXG59XG4iXX0= */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-export default function MyComponent(props) {
-  const {
-    a,
-    b,
-    ...rest
-  } = props;
-  const [count, setCount] = useState(0);
-  return _jsxs(_Fragment, {
-    children: [_jsx("button", {
-      css: _ref,
-      onClick: () => setCount(prevSize => prevSize + 1),
-      children: "Increment"
-    }), _jsx("div", {
-      height: count,
-      ...rest,
-      css: cssObj
-    })]
   });
 }
 `;
@@ -3330,75 +2593,6 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (development-modern) 1`] = `
-var _jsxFileName = "/emotion-classic.js",
-    _s = $RefreshSig$();
-
-function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
-
-import * as React from 'react';
-import { css } from '@emotion/react';
-import { jsx as ___EmotionJSX } from "@emotion/react";
-const cssObj = process.env.NODE_ENV === "production" ? {
-  name: "hwfcu5",
-  styles: "color:red"
-} : {
-  name: "aslxie-cssObj",
-  styles: "color:red;label:cssObj;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24tY2xhc3NpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFHZSIsImZpbGUiOiJlbW90aW9uLWNsYXNzaWMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgKiBhcyBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCB7Y3NzfSBmcm9tICdAZW1vdGlvbi9yZWFjdCdcblxuY29uc3QgY3NzT2JqID0gY3NzKHtjb2xvcjogJ3JlZCd9KVxuXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBNeUNvbXBvbmVudChwcm9wcykge1xuICBjb25zdCB7YSwgYiwgLi4ucmVzdH0gPSBwcm9wc1xuICBjb25zdCBbY291bnQsIHNldENvdW50XSA9IFJlYWN0LnVzZVN0YXRlKDApXG4gIHJldHVybiAoXG4gICAgPD5cbiAgICAgIDxidXR0b24gY3NzPXt7Y29sb3I6ICdibHVlJ319IG9uQ2xpY2s9eygpID0+IHNldENvdW50KChwcmV2U2l6ZSkgPT4gcHJldlNpemUgKyAxKX0+XG4gICAgICAgIEluY3JlbWVudFxuICAgICAgPC9idXR0b24+XG4gICAgICA8ZGl2IGhlaWdodD17Y291bnR9IHsuLi5yZXN0fSBjc3M9e2Nzc09ian0gLz5cbiAgICA8Lz5cbiAgKVxufVxuIl19 */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-var _ref = process.env.NODE_ENV === "production" ? {
-  name: "117wnve",
-  styles: "color:blue"
-} : {
-  name: "fveiva-MyComponent",
-  styles: "color:blue;label:MyComponent;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24tY2xhc3NpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFVYyIsImZpbGUiOiJlbW90aW9uLWNsYXNzaWMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgKiBhcyBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCB7Y3NzfSBmcm9tICdAZW1vdGlvbi9yZWFjdCdcblxuY29uc3QgY3NzT2JqID0gY3NzKHtjb2xvcjogJ3JlZCd9KVxuXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBNeUNvbXBvbmVudChwcm9wcykge1xuICBjb25zdCB7YSwgYiwgLi4ucmVzdH0gPSBwcm9wc1xuICBjb25zdCBbY291bnQsIHNldENvdW50XSA9IFJlYWN0LnVzZVN0YXRlKDApXG4gIHJldHVybiAoXG4gICAgPD5cbiAgICAgIDxidXR0b24gY3NzPXt7Y29sb3I6ICdibHVlJ319IG9uQ2xpY2s9eygpID0+IHNldENvdW50KChwcmV2U2l6ZSkgPT4gcHJldlNpemUgKyAxKX0+XG4gICAgICAgIEluY3JlbWVudFxuICAgICAgPC9idXR0b24+XG4gICAgICA8ZGl2IGhlaWdodD17Y291bnR9IHsuLi5yZXN0fSBjc3M9e2Nzc09ian0gLz5cbiAgICA8Lz5cbiAgKVxufVxuIl19 */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-export default function MyComponent(props) {
-  _s();
-
-  const {
-    a,
-    b,
-    ...rest
-  } = props;
-  const [count, setCount] = React.useState(0);
-  return ___EmotionJSX(React.Fragment, null, ___EmotionJSX("button", {
-    css: _ref,
-    onClick: () => setCount(prevSize => prevSize + 1),
-    __self: this,
-    __source: {
-      fileName: _jsxFileName,
-      lineNumber: 11,
-      columnNumber: 7
-    }
-  }, "Increment"), ___EmotionJSX("div", {
-    height: count,
-    ...rest,
-    css: cssObj,
-    __self: this,
-    __source: {
-      fileName: _jsxFileName,
-      lineNumber: 14,
-      columnNumber: 7
-    }
-  }));
-}
-
-_s(MyComponent, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");
-
-_c = MyComponent;
-
-var _c;
-
-$RefreshReg$(_c, "MyComponent");
-`;
-
 exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (esm) 1`] = `
 function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
 
@@ -3498,50 +2692,6 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles Emotion with classic runtime given {"emotion":true,"react":{"runtime":"classic"}}, {}: output (production-modern) 1`] = `
-function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."; }
-
-import * as React from 'react';
-import { css } from '@emotion/react';
-import { jsx as ___EmotionJSX } from "@emotion/react";
-const cssObj = process.env.NODE_ENV === "production" ? {
-  name: "hwfcu5",
-  styles: "color:red"
-} : {
-  name: "aslxie-cssObj",
-  styles: "color:red;label:cssObj;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24tY2xhc3NpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFHZSIsImZpbGUiOiJlbW90aW9uLWNsYXNzaWMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgKiBhcyBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCB7Y3NzfSBmcm9tICdAZW1vdGlvbi9yZWFjdCdcblxuY29uc3QgY3NzT2JqID0gY3NzKHtjb2xvcjogJ3JlZCd9KVxuXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBNeUNvbXBvbmVudChwcm9wcykge1xuICBjb25zdCB7YSwgYiwgLi4ucmVzdH0gPSBwcm9wc1xuICBjb25zdCBbY291bnQsIHNldENvdW50XSA9IFJlYWN0LnVzZVN0YXRlKDApXG4gIHJldHVybiAoXG4gICAgPD5cbiAgICAgIDxidXR0b24gY3NzPXt7Y29sb3I6ICdibHVlJ319IG9uQ2xpY2s9eygpID0+IHNldENvdW50KChwcmV2U2l6ZSkgPT4gcHJldlNpemUgKyAxKX0+XG4gICAgICAgIEluY3JlbWVudFxuICAgICAgPC9idXR0b24+XG4gICAgICA8ZGl2IGhlaWdodD17Y291bnR9IHsuLi5yZXN0fSBjc3M9e2Nzc09ian0gLz5cbiAgICA8Lz5cbiAgKVxufVxuIl19 */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-var _ref = process.env.NODE_ENV === "production" ? {
-  name: "117wnve",
-  styles: "color:blue"
-} : {
-  name: "fveiva-MyComponent",
-  styles: "color:blue;label:MyComponent;",
-  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24tY2xhc3NpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFVYyIsImZpbGUiOiJlbW90aW9uLWNsYXNzaWMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgKiBhcyBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCB7Y3NzfSBmcm9tICdAZW1vdGlvbi9yZWFjdCdcblxuY29uc3QgY3NzT2JqID0gY3NzKHtjb2xvcjogJ3JlZCd9KVxuXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBNeUNvbXBvbmVudChwcm9wcykge1xuICBjb25zdCB7YSwgYiwgLi4ucmVzdH0gPSBwcm9wc1xuICBjb25zdCBbY291bnQsIHNldENvdW50XSA9IFJlYWN0LnVzZVN0YXRlKDApXG4gIHJldHVybiAoXG4gICAgPD5cbiAgICAgIDxidXR0b24gY3NzPXt7Y29sb3I6ICdibHVlJ319IG9uQ2xpY2s9eygpID0+IHNldENvdW50KChwcmV2U2l6ZSkgPT4gcHJldlNpemUgKyAxKX0+XG4gICAgICAgIEluY3JlbWVudFxuICAgICAgPC9idXR0b24+XG4gICAgICA8ZGl2IGhlaWdodD17Y291bnR9IHsuLi5yZXN0fSBjc3M9e2Nzc09ian0gLz5cbiAgICA8Lz5cbiAgKVxufVxuIl19 */",
-  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
-};
-
-export default function MyComponent(props) {
-  const {
-    a,
-    b,
-    ...rest
-  } = props;
-  const [count, setCount] = React.useState(0);
-  return ___EmotionJSX(React.Fragment, null, ___EmotionJSX("button", {
-    css: _ref,
-    onClick: () => setCount(prevSize => prevSize + 1)
-  }, "Increment"), ___EmotionJSX("div", {
-    height: count,
-    ...rest,
-    css: cssObj
-  }));
-}
-`;
-
 exports[`transpiles React given {}, {}: input 1`] = `
 import {useState} from 'react'
 
@@ -3626,40 +2776,6 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React given {}, {}: output (development-modern) 1`] = `
-var _jsxFileName = "/react.js",
-    _s = $RefreshSig$();
-
-import { useState } from 'react';
-import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
-export default function MyComponent(props) {
-  _s();
-
-  const {
-    label,
-    ...rest
-  } = props;
-  const [count, setCount] = useState(0);
-  return /*#__PURE__*/_jsxDEV("button", {
-    onClick: () => setCount(count + 1),
-    ...rest,
-    children: [label, " ", count]
-  }, void 0, true, {
-    fileName: _jsxFileName,
-    lineNumber: 7,
-    columnNumber: 5
-  }, this);
-}
-
-_s(MyComponent, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");
-
-_c = MyComponent;
-
-var _c;
-
-$RefreshReg$(_c, "MyComponent");
-`;
-
 exports[`transpiles React given {}, {}: output (esm) 1`] = `
 import { useState } from 'react';
 import { jsxs as _jsxs } from "react/jsx-runtime";
@@ -3699,23 +2815,6 @@ export default function MyComponent(props) {
   }, rest, {
     children: [label, " ", count]
   }));
-}
-`;
-
-exports[`transpiles React given {}, {}: output (production-modern) 1`] = `
-import { useState } from 'react';
-import { jsxs as _jsxs } from "react/jsx-runtime";
-export default function MyComponent(props) {
-  const {
-    label,
-    ...rest
-  } = props;
-  const [count, setCount] = useState(0);
-  return /*#__PURE__*/_jsxs("button", {
-    onClick: () => setCount(count + 1),
-    ...rest,
-    children: [label, " ", count]
-  });
 }
 `;
 
@@ -3802,40 +2901,6 @@ var _c;
 $RefreshReg$(_c, "MyComponent");
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (development-modern) 1`] = `
-var _jsxFileName = "/react-classic.js",
-    _s = $RefreshSig$();
-
-import * as React from 'react';
-export default function MyComponent(props) {
-  _s();
-
-  const {
-    label,
-    ...rest
-  } = props;
-  const [count, setCount] = React.useState(0);
-  return /*#__PURE__*/React.createElement("button", {
-    onClick: () => setCount(count + 1),
-    ...rest,
-    __self: this,
-    __source: {
-      fileName: _jsxFileName,
-      lineNumber: 7,
-      columnNumber: 5
-    }
-  }, label, " ", count);
-}
-
-_s(MyComponent, "oDgYfYHkD9Wkv4hrAPCkI/ev3YU=");
-
-_c = MyComponent;
-
-var _c;
-
-$RefreshReg$(_c, "MyComponent");
-`;
-
 exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (esm) 1`] = `
 import * as React from 'react';
 export default function MyComponent(props) {
@@ -3873,21 +2938,6 @@ export default function MyComponent(props) {
 }
 `;
 
-exports[`transpiles React with classic runtime given {"react":{"runtime":"classic"}}, {}: output (production-modern) 1`] = `
-import * as React from 'react';
-export default function MyComponent(props) {
-  const {
-    label,
-    ...rest
-  } = props;
-  const [count, setCount] = React.useState(0);
-  return /*#__PURE__*/React.createElement("button", {
-    onClick: () => setCount(count + 1),
-    ...rest
-  }, label, " ", count);
-}
-`;
-
 exports[`transpiles TSX given {}, {}: input 1`] = `
 export default function add(a: number, b: number): number {
   return a + b
@@ -3914,12 +2964,6 @@ export default function add(a, b) {
 }
 `;
 
-exports[`transpiles TSX given {}, {}: output (development-modern) 1`] = `
-export default function add(a, b) {
-  return a + b;
-}
-`;
-
 exports[`transpiles TSX given {}, {}: output (esm) 1`] = `
 export default function add(a, b) {
   return a + b;
@@ -3927,12 +2971,6 @@ export default function add(a, b) {
 `;
 
 exports[`transpiles TSX given {}, {}: output (production) 1`] = `
-export default function add(a, b) {
-  return a + b;
-}
-`;
-
-exports[`transpiles TSX given {}, {}: output (production-modern) 1`] = `
 export default function add(a, b) {
   return a + b;
 }

--- a/fixtures/.browserslistrc
+++ b/fixtures/.browserslistrc
@@ -1,8 +1,0 @@
-[production]
-Chrome 88
-Firefox 78
-IE 11
-
-[modern]
-Chrome 88
-Firefox 85

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function getUnsupportedEnvMessage(env) {
 function getDefaultTargets(env) {
   if (env === 'test') return {node: true, browsers: []}
   if (env === 'esm' || env === 'cjs') return {node: '14.14', browsers: []}
-  return undefined // targets will be overridden using the browserslistEnv preset-env config
+  return undefined
 }
 
 module.exports = (babel, options) => {

--- a/index.js
+++ b/index.js
@@ -36,15 +36,7 @@ const assumptions = {
   superIsCallableConstructor: true,
 }
 
-const SUPPORTED_ENVIRONMENTS = [
-  'development',
-  'production',
-  'esm',
-  'cjs',
-  'test',
-  'development-modern',
-  'production-modern',
-]
+const SUPPORTED_ENVIRONMENTS = ['development', 'production', 'esm', 'cjs', 'test']
 
 function getUnsupportedEnvMessage(env) {
   const supportedEnvsString = SUPPORTED_ENVIRONMENTS.join(', ')
@@ -64,17 +56,12 @@ module.exports = (babel, options) => {
     throw new Error(getUnsupportedEnvMessage(env))
   }
 
-  const isModern = env === 'development-modern' || env === 'production-modern'
-  const isDevelopment = env === 'development' || env === 'development-modern'
-  const isProduction = env === 'production' || env === 'production-modern'
-
   const {
-    browserslistEnv = isModern ? 'modern' : undefined,
     emotion = false,
-    include = isDevelopment || isProduction ? APP_PLUGIN_INCLUDE_LIST : [],
+    include = env === 'development' || env === 'production' ? APP_PLUGIN_INCLUDE_LIST : [],
     modules = env === 'test' || env === 'cjs' ? 'commonjs' : false,
     react = {},
-    reactRefresh = isDevelopment && react && {},
+    reactRefresh = env === 'development' && react && {},
     runtime = true,
     targets = getDefaultTargets(env),
     typescript = {},
@@ -101,7 +88,6 @@ module.exports = (babel, options) => {
         require('@babel/preset-env').default,
         {
           ...rest,
-          browserslistEnv,
           include,
           modules,
           targets,
@@ -128,7 +114,7 @@ module.exports = (babel, options) => {
       react && [
         require('@babel/preset-react').default,
         {
-          development: isDevelopment,
+          development: env === 'development',
           importSource: emotion && reactRuntime === 'automatic' ? '@emotion/react' : undefined,
           useSpread: true,
           ...react,

--- a/test.ts
+++ b/test.ts
@@ -1,20 +1,13 @@
 import * as fs from 'fs'
 
 import {test, expect} from '@jest/globals'
-import {transform} from '@babel/core'
+import {transformSync} from '@babel/core'
 
 import preset from '.'
 
 // the 'test' environment is excluded because it targets the currently running version of Node
 // since our CI runs multiple Node versions, a snapshot for 'test' might not match one of them
-const NON_TEST_ENVIRONMENTS = [
-  'development',
-  'production',
-  'esm',
-  'cjs',
-  'development-modern',
-  'production-modern',
-]
+const NON_TEST_ENVIRONMENTS = ['development', 'production', 'esm', 'cjs']
 
 expect.addSnapshotSerializer({
   test: (val: unknown) => typeof val === 'string',
@@ -29,15 +22,10 @@ function macro(title: string, fixture: string, presetOptions = {}, topLevelOptio
     const input = fs.readFileSync(file, 'utf8')
     expect(input).toMatchSnapshot('input')
 
-    const resolvedPresetOptions = {
-      ...presetOptions,
-      configPath: `${__dirname}/fixtures`,
-    }
-
     NON_TEST_ENVIRONMENTS.forEach((envName) => {
-      const result = transform(input, {
+      const result = transformSync(input, {
         envName,
-        presets: [[preset, resolvedPresetOptions]],
+        presets: [[preset, presetOptions]],
         filename: `/${fixture}`,
         babelrc: false,
         ...topLevelOptions,
@@ -48,7 +36,7 @@ function macro(title: string, fixture: string, presetOptions = {}, topLevelOptio
 }
 
 macro('transpiles ES2020+ syntax', 'syntax.js')
-macro('transpiles ES2020+ syntax', 'syntax.js', {targets: 'Chrome 88'})
+macro('transpiles ES2020+ syntax', 'syntax.js', undefined, {targets: 'Chrome 88'})
 macro('transpiles ES2020+ syntax', 'syntax.js', {runtime: false})
 macro('transpiles ES2020+ syntax', 'syntax.js', {modules: 'commonjs'})
 macro('transpiles ES2020+ syntax', 'syntax.js', undefined, {
@@ -65,6 +53,9 @@ macro('transpiles Emotion with classic runtime', 'emotion-classic.js', {
 })
 
 macro('replaces generic polyfill with env-targeted polyfills', 'polyfills.js')
+macro('replaces generic polyfill with env-targeted polyfills', 'polyfills.js', undefined, {
+  targets: 'Chrome 88',
+})
 
 macro('transpiles ESM in node_modules', 'vendor/node_modules/my-pkg/index.js')
 macro('transpiles CJS in node_modules', 'vendor/node_modules/my-pkg/cjs.js')


### PR DESCRIPTION
Closes https://github.com/kensho-technologies/babel-preset/issues/108.

Reverts the modern envs from https://github.com/kensho-technologies/babel-preset/pull/88 since, per the issue, the browserslist env will be specified by apps as a top-level compiler option now. Hopefully these can be brought back into the preset someday if something like https://github.com/babel/babel/issues/13317 is implemented. Another option is a higher-order Babel preset but I'd like to try to avoid that since it's so far from idiomatic Babel config.

I kept most of the runtime env assertion and the changes to the test suite since they're general, although the format will be ported to https://github.com/kensho-technologies/babel-preset/pull/117 shortly. I did remove the browserslistrc file in the fixtures directory in favor of specifying targets explicitly as options, since these resolve equivalently and at that point we're just re-testing `@babel/preset-env`. I also removed the `browserslistEnv` docs since it's just a straight passthrough to the env preset but ideally this should be specified as a top-level compiler option now anyway. I'll add some dual bundle guidance to internal docs.