### PR TITLE
Use built-in npm cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm install -g npm@7
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
See [this post](https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/). Same behavior, less config, cross-platform.